### PR TITLE
New link for hosted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ National Water Information System (NWIS).
 
 Note that the python version is not a direct port of the original: it attempts to reproduce the functionality of the R package,
 though its organization and interface often differ.
+For additional information on `dataretrieval` visit the [documentation](https://rconnect.chs.usgs.gov/python-dataretrieval-docs/).
 
 If there's a hydrologic or environmental data portal that you'd like dataretrieval to 
 work with, raise it as an [issue](https://github.com/USGS-python/dataretrieval/issues).


### PR DESCRIPTION
Repository migration has resulted in a loss of the GitHub Pages documentation hosting. I've created a stopgap measure that is hosted here: https://rconnect.chs.usgs.gov/python-dataretrieval-docs/

The build behind the scenes happens nightly at 3AM Eastern and __pulls from this repository__ using the "gh-pages" branch, so it is __important that we keep the "GitHub Pages" build__ as part of the CI in this repository, as that pushes the latest content to the "gh-pages" branch where it can be read and incorporated into these new docs on a nightly basis.

@thodson-usgs if you could modify the link on the sidebar to point to these new documentation that'd be great as the current link is now broken (and I've lost editing privileges in this repository). 