### PR TITLE
make Metadata a dataclass

### DIFF
--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -6,7 +6,7 @@ import pandas as pd
 import requests
 import dataretrieval
 from dataretrieval.codes import tz
-
+from dataclasses import dataclass
 
 def to_str(listlike, delimiter=','):
     """Translates list-like objects into strings.
@@ -135,7 +135,7 @@ def update_merge(left, right, na_only=False, on=None, **kwargs):
 
     return df
 
-
+@dataclass
 class Metadata:
     """Custom class for metadata.
     """
@@ -234,3 +234,6 @@ class NoSitesError(Exception):
 
     def __str__(self):
         return "No sites/data found using the selection criteria specified in url: {}".format(self.url)
+
+if __name__ == "__main__":
+    pass

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -235,5 +235,3 @@ class NoSitesError(Exception):
     def __str__(self):
         return "No sites/data found using the selection criteria specified in url: {}".format(self.url)
 
-if __name__ == "__main__":
-    pass


### PR DESCRIPTION
Currently, the [Metadata class](https://github.com/DOI-USGS/dataretrieval-python/blob/dab0f51774cc10776a3ab2b009262ea9173c8d51/dataretrieval/utils.py#L139C1-L139C2) has no `__init__` function but only class variables. 

```python
class Metadata:
    """Custom class for metadata.
    """
    url = None
    query_time = None
    site_info = None
    header = None
    variable_info = None
    comment = None

    # note sure what statistic_info is
    statistic_info = None
    # disclaimer seems to be only part of importWaterML1
    disclaimer = None
```

I think these are not meant to be class variables but **instance** variables, as different data requests will return different metadata. Check an example of the difference in https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables. Only `utils.set_metadata` creates Metadata objects and assigns values to the instance object variables, without ever modifying the default `None` of the class variables. `nwis._set_metadata` behaves similarly in that it only modify objects but never the class itself. 

Making the Metadata a [dataclass](https://docs.python.org/3.8/library/dataclasses.html) helps with making those (url, site_info, etc) instance attributes, without the need to write a long `__init__` function. Dataclasses have been part of the standard library since 3.7 so there should not be compatibility issues. 

*****
- All tests passing from the test folder using pytest. 
