### PR TITLE
Adjust code.json to point to new repo location

### DIFF
--- a/code.json
+++ b/code.json
@@ -11,15 +11,15 @@
       "licenses": [
         {
           "name": "Public Domain, CC0-1.0",
-          "URL": "https://code.usgs.gov/cmwsc/shwa/dataretrieval/-/raw/v1.0.2/LICENSE.md"
+          "URL": "https://code.usgs.gov/water/dataretrieval-python/-/raw/v1.0.2/LICENSE.md"
         }
       ]
     },
 
-    "homepageURL": "https://code.usgs.gov/cmwsc/shwa/dataretrieval",
-    "downloadURL": "https://code.usgs.gov/cmwsc/shwa/dataretrieval/-/archive/v1.0.2/dataretrieval-v1.0.2.zip",
-    "disclaimerURL": "https://code.usgs.gov/cmwsc/shwa/dataretrieval/-/raw/v1.0.2/DISCLAIMER.md",
-    "repositoryURL": "https://code.usgs.gov/cmwsc/shwa/dataretrieval.git",
+    "homepageURL": "https://code.usgs.gov/water/dataretrieval-python",
+    "downloadURL": "https://code.usgs.gov/water/dataretrieval-python/-/archive/v1.0.2/dataretrieval-python-v1.0.2.zip",
+    "disclaimerURL": "https://code.usgs.gov/water/dataretrieval-python/-/raw/v1.0.2/DISCLAIMER.md",
+    "repositoryURL": "https://code.usgs.gov/water/dataretrieval-python.git",
     "vcs": "git",
 
     "laborHours": 0,


### PR DESCRIPTION
To make the official release public again, we need to go through the Software Management official release process checklist. I believe we can use most of the info @thodson-usgs provided in [2023](https://code.chs.usgs.gov/software/software-management/-/issues/936), but @ldecicco-USGS noticed that the code.json file still contains the outdated repo info. I have updated it in this PR. Once merged with `master`, I will sync it with GitLab and then make the exact same change to the tagged official release (v1.0.2). Does that sound good?

One question: should we change the metadataLastUpdated (line 42) date in the code.json file?