### PR TITLE
Update GH action tags to most recent release commit hashes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,7 +2,7 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
 # This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
+# They are provided by a third-party and are governed  by
 # separate terms of service, privacy policy, and support
 # documentation.
 

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           persist-credentials: false
       - name: Install dataretrieval, dependencies, and Sphinx then build docs
@@ -31,7 +31,7 @@ jobs:
           echo ${{ github.ref == 'refs/heads/main' }}
           echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There is a potential security risk where the maintainer of a GitHub Action could retroactively change the code associated with specific, tagged versions of the action (e.g., v1, v2). Laura DeCicco proposed an alternative to replace version numbers in GitHub Action yml files with the specific commit hashes associated with those release versions, which are immutable.

This PR makes those changes for the seven instances where an external action is invoked. I couldn't identify the exact version for some of the actions (e.g., there are multiple v2.#.# versions for the checkout action), so I just selected the hashes associated with the most recently released version for each action. 