### PR TITLE
fix!: correct `nwis` module GeoDataFrames crs to EPSG:4269 (NAD 83)

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -44,7 +44,8 @@ WATERDATA_SERVICES = [
     "water_use",
     "ratings",
 ]
-_CRS = "EPSG:4236"
+# NAD83
+_CRS = "EPSG:4269"
 
 
 def format_response(


### PR DESCRIPTION
BREAKING CHANGE: [v1.0.10](https://github.com/DOI-USGS/dataretrieval-python/releases/tag/v1.0.10) is the only affected version. See footer for more detail.

The nwis site service (and the USGS more broadly) uses the NAD83 crs.

64a575d introduced a bug that hard coded the nwis module's crs to EPSG:4236 -- Hu Tzu Shan 1950 (https://epsg.io/4236). I guarantee 64a575d meant to hard code _EPSG:4326_ -- WGS84. It appears it was fat fingered and missed in #143's PR review (it happens to the best of us:)).

Bug reproduction:
```python
import dataretrieval
from dataretrieval import nwis

assert dataretrieval.__version__ == "1.0.10"

df, metadata = nwis.get_info(sites="01013500")
assert df.crs.to_epsg() == 4236
```

In either case, EPSG:4326 is still _technically_ the wrong crs. For example:

https://waterservices.usgs.gov/nwis/site?sites=01013500&siteOutput=Expanded&format=rdb

returns (truncated)
```
USGS 01013500 ... NAD83
```
for the field `coord_datum_cd  -- Latitude-longitude datum`. 

So, EPSG:4269 -- NAD83 is the correct crs. To my understanding the default crs used by the USGS is NAD83 (please check me on this). There are exceptions for example, the NLDI service provides GeoJSON data which the spec specified should be in EPSG:4326 -- WGS84.

There is room for discussion if NAD 83 vs WGS 84 really matters in the conterminous US however for Alaska errors in both the x and y direction can be upwards of 1 meter in either direction.

BREAKING CHANGE: [v1.0.10](https://github.com/DOI-USGS/dataretrieval-python/releases/tag/v1.0.10) is the only affected version. The GeoDataFrames returned from the following functions now correctly have a crs of EPSG:4269. In [v1.0.10](https://github.com/DOI-USGS/dataretrieval-python/releases/tag/v1.0.10) they mistakenly returned with a crs of [EPSG:4236 -- Hu Tzu Shan 1950](https://epsg.io/4236).

`dataretrieval.nwis.get_qwdata`
`dataretrieval.nwis.get_discharge_measurements`
`dataretrieval.nwis.get_discharge_peaks`
`dataretrieval.nwis.get_gwlevels`
`dataretrieval.nwis.get_stats`
`dataretrieval.nwis.get_info`
`dataretrieval.nwis.get_pmcodes`
`dataretrieval.nwis.get_water_use`
`dataretrieval.nwis.get_ratings`
`dataretrieval.nwis.what_sites`
`dataretrieval.nwis.get_dv`
`dataretrieval.nwis.get_iv`