### PR TITLE
Fix gwlevels pcode

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -460,6 +460,13 @@ def get_gwlevels(
 
     if datetime_index is True:
         df = format_datetime(df, "lev_dt", "lev_tm", "lev_tz_cd")
+    
+    # Filter by kwarg parameterCd because the service doesn't do it
+    if "parameterCd" in kwargs:
+        pcodes = kwargs["parameterCd"]
+        if isinstance(pcodes, str):
+            pcodes = [pcodes]
+        df = df[df["parameter_cd"].isin(pcodes)]
 
     return format_response(df, **kwargs), NWIS_Metadata(response, **kwargs)
 

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -12,6 +12,7 @@ from dataretrieval.nwis import (
     get_record,
     preformat_peaks_response,
     what_sites,
+    get_gwlevels
 )
 
 START_DATE = "2018-01-24"
@@ -296,3 +297,25 @@ class TestMetaData:
         md = NWIS_Metadata(response, countyCd="01001")
         # assert that site_info is implemented
         assert md.site_info
+
+class Testgwlevels:
+    """Tests of get_gwlevels function
+
+    Notes
+    -----
+    - gwlevels moved to a new web service endpoint in 2024
+    - The new endpoint has quirks and doesn't recognize the 
+        parameterCd kwarg advertisted by the service.
+    """
+    def test_gwlevels_one_parameterCd(self):
+        pcode = "72019"
+        df,_ = get_gwlevels(sites="434400121275801", start = "2010-01-01", parameterCd=pcode)
+        assert set(df['parameter_cd'].unique().tolist()) == set([pcode])
+
+    def test_gwlevels_two_parameterCds(self):
+        pcode = ["72019", "62610"]
+        df,_ = get_gwlevels(sites="434400121275801", start = "2010-01-01", parameterCd=pcode)
+        assert set(df['parameter_cd'].unique().tolist()) == set(pcode)
+
+    
+


### PR DESCRIPTION
This small PR adds a filtering step to the `get_gwlevels` function that ensures only the requested pcodes are returned. For whatever reason, the "new" gwlevels endpoint doesn't seem to recognize the `parameterCd` argument, even though it is still specified in the documentation: https://nwis.waterservices.usgs.gov/docs/groundwater-levels/groundwater-levels-details/

See Issue #179 