### PR TITLE
Add waterdata infrastructure

### DIFF
--- a/dataretrieval/waterdata.py
+++ b/dataretrieval/waterdata.py
@@ -93,7 +93,7 @@ def get_daily(
         max_results: Optional[int] = None,
         convertType: bool = True
     ) -> pd.DataFrame:
-    
+
     service = "daily"
     output_id = "daily_id"
 
@@ -106,7 +106,55 @@ def get_daily(
 
     return waterdata_helpers.get_ogc_data(args, output_id, service)
 
-def get_monitoring_locations() -> pd.DataFrame: 
+def get_monitoring_locations(
+        monitoring_location_id: Optional[List[str]] = None,
+        agency_code: Optional[List[str]] = None,
+        agency_name: Optional[List[str]] = None,
+        monitoring_location_number: Optional[List[str]] = None,
+        monitoring_location_name: Optional[List[str]] = None,
+        district_code: Optional[List[str]] = None,
+        country_code: Optional[List[str]] = None,
+        country_name: Optional[List[str]] = None,
+        state_code: Optional[List[str]] = None,
+        state_name: Optional[List[str]] = None,
+        county_code: Optional[List[str]] = None,
+        county_name: Optional[List[str]] = None,
+        minor_civil_division_code: Optional[List[str]] = None,
+        site_type_code: Optional[List[str]] = None,
+        site_type: Optional[List[str]] = None,
+        hydrologic_unit_code: Optional[List[str]] = None,
+        basin_code: Optional[List[str]] = None,
+        altitude: Optional[List[str]] = None,
+        altitude_accuracy: Optional[List[str]] = None,
+        altitude_method_code: Optional[List[str]] = None,
+        altitude_method_name: Optional[List[str]] = None,             
+        vertical_datum: Optional[List[str]] = None,
+        vertical_datum_name: Optional[List[str]] = None,
+        horizontal_positional_accuracy_code: Optional[List[str]] = None,
+        horizontal_positional_accuracy: Optional[List[str]] = None,
+        horizontal_position_method_code: Optional[List[str]] = None,
+        horizontal_position_method_name: Optional[List[str]] = None,
+        original_horizontal_datum: Optional[List[str]] = None,
+        original_horizontal_datum_name: Optional[List[str]] = None,
+        drainage_area: Optional[List[str]] = None,
+        contributing_drainage_area: Optional[List[str]] = None,    
+        time_zone_abbreviation: Optional[List[str]] = None,
+        uses_daylight_savings: Optional[List[str]] = None,
+        construction_date: Optional[List[str]] = None,
+        aquifer_code: Optional[List[str]] = None,
+        national_aquifer_code: Optional[List[str]] = None,
+        aquifer_type_code: Optional[List[str]] = None,
+        well_constructed_depth: Optional[List[str]] = None,
+        hole_constructed_depth: Optional[List[str]] = None,
+        depth_source_code: Optional[List[str]] = None,
+        properties: Optional[List[str]] = None,
+        skipGeometry: Optional[bool] = None,
+        time: Optional[Union[str, List[str]]] = None,
+        bbox: Optional[List[float]] = None,
+        limit: Optional[int] = None,
+        max_results: Optional[int] = None,
+        convertType: bool = True
+        ) -> pd.DataFrame: 
     service = "monitoring-locations"
     output_id = "monitoring_location_id"
 
@@ -119,7 +167,32 @@ def get_monitoring_locations() -> pd.DataFrame:
 
     return waterdata_helpers.get_ogc_data(args, output_id, service)
 
-def get_ts_meta() -> pd.DataFrame:
+def get_timeseries_metadata(
+        monitoring_location_id: Optional[Union[str, List[str]]] = None,
+        parameter_code: Optional[Union[str, List[str]]] = None,
+        parameter_name: Optional[Union[str, List[str]]] = None,
+        properties: Optional[Union[str, List[str]]] = None,
+        statistic_id: Optional[Union[str, List[str]]] = None,
+        last_modified: Optional[Union[str, List[str]]] = None,
+        begin: Optional[Union[str, List[str]]] = None,
+        end: Optional[Union[str, List[str]]] = None,
+        unit_of_measure: Optional[Union[str, List[str]]] = None,
+        computation_period_identifier: Optional[Union[str, List[str]]] = None,
+        computation_identifier: Optional[Union[str, List[str]]] = None,
+        thresholds: Optional[int] = None,
+        sublocation_identifier: Optional[Union[str, List[str]]] = None,
+        primary: Optional[Union[str, List[str]]] = None,
+        parent_time_series_id: Optional[Union[str, List[str]]] = None,
+        time_series_id: Optional[Union[str, List[str]]] = None,
+        web_description: Optional[Union[str, List[str]]] = None,
+        skipGeometry: Optional[bool] = None,
+        time: Optional[Union[str, List[str]]] = None,
+        bbox: Optional[List[float]] = None,
+        limit: Optional[int] = None,
+        max_results: Optional[int] = None,
+        convertType: bool = True
+) -> pd.DataFrame:
+
     service = "time-series-metadata"
     output_id = "time_series_id"
 
@@ -132,7 +205,25 @@ def get_ts_meta() -> pd.DataFrame:
 
     return waterdata_helpers.get_ogc_data(args, output_id, service)
 
-def get_latest_continuous() -> pd.DataFrame:
+def get_latest_continuous(
+        monitoring_location_id: Optional[Union[str, List[str]]] = None,
+        parameter_code: Optional[Union[str, List[str]]] = None,
+        statistic_id: Optional[Union[str, List[str]]] = None,
+        properties: Optional[Union[str, List[str]]] = None,
+        time_series_id: Optional[Union[str, List[str]]] = None,
+        latest_continuous_id: Optional[Union[str, List[str]]] = None,
+        approval_status: Optional[Union[str, List[str]]] = None,
+        unit_of_measure: Optional[Union[str, List[str]]] = None,
+        qualifier: Optional[Union[str, List[str]]] = None,
+        value: Optional[int] = None,
+        last_modified: Optional[Union[str, List[str]]] = None,
+        skipGeometry: Optional[bool] = None,
+        time: Optional[Union[str, List[str]]] = None,
+        bbox: Optional[List[float]] = None,
+        limit: Optional[int] = None,
+        max_results: Optional[int] = None,
+        convertType: bool = True
+        ) -> pd.DataFrame:
     service = "latest-continuous"
     output_id = "latest_continuous_id"
 
@@ -145,7 +236,27 @@ def get_latest_continuous() -> pd.DataFrame:
 
     return waterdata_helpers.get_ogc_data(args, output_id, service)
 
-def get_field_measurements() -> pd.DataFrame:
+def get_field_measurements(
+        monitoring_location_id: Optional[Union[str, List[str]]] = None,
+        parameter_code: Optional[Union[str, List[str]]] = None,
+        observing_procedure_code: Optional[Union[str, List[str]]] = None,
+        properties: Optional[List[str]] = None,
+        field_visit_id: Optional[Union[str, List[str]]] = None,
+        approval_status: Optional[Union[str, List[str]]] = None,
+        unit_of_measure: Optional[Union[str, List[str]]] = None,
+        qualifier: Optional[Union[str, List[str]]] = None,
+        value: Optional[Union[str, List[str]]] = None,
+        last_modified: Optional[Union[str, List[str]]] = None,
+        observing_procedure: Optional[Union[str, List[str]]] = None,
+        vertical_datum: Optional[Union[str, List[str]]] = None,
+        measuring_agency: Optional[Union[str, List[str]]] = None,
+        skipGeometry: Optional[bool] = None,
+        time: Optional[Union[str, List[str]]] = None,
+        bbox: Optional[List[float]] = None,
+        limit: Optional[int] = None,
+        max_results: Optional[int] = None,
+        convertType: bool = True
+        ) -> pd.DataFrame:
     service = "field-measurements"
     output_id = "field_measurement_id"
 

--- a/dataretrieval/waterdata.py
+++ b/dataretrieval/waterdata.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import json
 from io import StringIO
-from typing import TYPE_CHECKING, Literal, get_args
+from typing import TYPE_CHECKING, Literal, List, get_args
 
 import pandas as pd
 import requests
 from requests.models import PreparedRequest
 
 from dataretrieval.utils import BaseMetadata, to_str
+import dataretrieval.waterdata_helpers
 
 if TYPE_CHECKING:
     from typing import Optional, Tuple, Union
@@ -21,7 +22,9 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
 
-_BASE_URL = "https://api.waterdata.usgs.gov/samples-data"
+_BASE_URL = "https://api.waterdata.usgs.gov/"
+
+_SAMPLES_URL = _BASE_URL + "samples-data"
 
 _CODE_SERVICES = Literal[
     "characteristicgroup",
@@ -33,7 +36,6 @@ _CODE_SERVICES = Literal[
     "sitetype",
     "states",
 ]
-
 
 _SERVICES = Literal["activities", "locations", "organizations", "projects", "results"]
 
@@ -72,6 +74,40 @@ _PROFILE_LOOKUP = {
     ],
 }
 
+def get_daily(
+        monitoring_location_id: Optional[Union[str, List[str]]] = None,
+        parameter_code: Optional[Union[str, List[str]]] = None,
+        statistic_id: Optional[Union[str, List[str]]] = None,
+        properties: Optional[List[str]] = None,
+        time_series_id: Optional[Union[str, List[str]]] = None,
+        daily_id: Optional[Union[str, List[str]]] = None,
+        approval_status: Optional[Union[str, List[str]]] = None,
+        unit_of_measure: Optional[Union[str, List[str]]] = None,
+        qualifier: Optional[Union[str, List[str]]] = None,
+        value: Optional[Union[str, List[str]]] = None,
+        last_modified: Optional[str] = None,
+        skipGeometry: Optional[bool] = None,
+        time: Optional[Union[str, List[str]]] = None,
+        bbox: Optional[List[float]] = None,
+        limit: Optional[int] = None,
+        max_results: Optional[int] = None,
+        convertType: bool = True
+    ) -> pd.DataFrame:
+    
+    service = "daily"
+    output_id = "daily_id"
+
+    return_list = _get_ogc_data(
+
+    )
+
+def get_monitoring_locations(): 
+
+def get_ts_meta():
+
+def get_latest_continuous():
+
+def get_field_measurements():
  
 def get_codes(code_service: _CODE_SERVICES) -> DataFrame:
     """Return codes from a Samples code service.
@@ -90,7 +126,7 @@ def get_codes(code_service: _CODE_SERVICES) -> DataFrame:
             f"Valid options are: {valid_code_services}."
         )
 
-    url = f"{_BASE_URL}/codeservice/{code_service}?mimeType=application%2Fjson"
+    url = f"{_SAMPLES_URL}/codeservice/{code_service}?mimeType=application%2Fjson"
     
     response = requests.get(url)
     
@@ -305,7 +341,7 @@ def get_samples(
     if "boundingBox" in params:
         params["boundingBox"] = to_str(params["boundingBox"])
 
-    url = f"{_BASE_URL}/{service}/{profile}"
+    url = f"{_SAMPLES_URL}/{service}/{profile}"
 
     req = PreparedRequest()
     req.prepare_url(url, params=params)

--- a/dataretrieval/waterdata.py
+++ b/dataretrieval/waterdata.py
@@ -104,7 +104,7 @@ def get_daily(
     }
     args["convertType"] = False
 
-    return waterdata_helpers._get_ogc_data(args, output_id, service)
+    return waterdata_helpers.get_ogc_data(args, output_id, service)
 
 # def get_monitoring_locations(): 
 #     service = "monitoring-locations"
@@ -117,7 +117,7 @@ def get_daily(
 #     }
 #     args["convertType"] = False
 
-#     return _get_ogc_data(args, output_id, service)
+#     return waterdata_helpers.get_ogc_data(args, output_id, service)
 
 # def get_ts_meta():
 

--- a/dataretrieval/waterdata.py
+++ b/dataretrieval/waterdata.py
@@ -14,7 +14,7 @@ import requests
 from requests.models import PreparedRequest
 
 from dataretrieval.utils import BaseMetadata, to_str
-import dataretrieval.waterdata_helpers
+from dataretrieval import waterdata_helpers
 
 if TYPE_CHECKING:
     from typing import Optional, Tuple, Union
@@ -97,17 +97,33 @@ def get_daily(
     service = "daily"
     output_id = "daily_id"
 
-    return_list = _get_ogc_data(
+    # Build argument dictionary, omitting None values
+    args = { 
+        k: v for k, v in locals().items()
+        if k not in {"service", "output_id"} and v is not None
+    }
+    args["convertType"] = False
 
-    )
+    return waterdata_helpers._get_ogc_data(args, output_id, service)
 
-def get_monitoring_locations(): 
+# def get_monitoring_locations(): 
+#     service = "monitoring-locations"
+#     output_id = "monitoring_location_id"
 
-def get_ts_meta():
+#     # Build argument dictionary, omitting None values
+#     args = { 
+#         k: v for k, v in locals().items()
+#         if k not in {"service", "output_id"} and v is not None
+#     }
+#     args["convertType"] = False
 
-def get_latest_continuous():
+#     return _get_ogc_data(args, output_id, service)
 
-def get_field_measurements():
+# def get_ts_meta():
+
+# def get_latest_continuous():
+
+# def get_field_measurements():
  
 def get_codes(code_service: _CODE_SERVICES) -> DataFrame:
     """Return codes from a Samples code service.

--- a/dataretrieval/waterdata.py
+++ b/dataretrieval/waterdata.py
@@ -106,24 +106,57 @@ def get_daily(
 
     return waterdata_helpers.get_ogc_data(args, output_id, service)
 
-# def get_monitoring_locations(): 
-#     service = "monitoring-locations"
-#     output_id = "monitoring_location_id"
+def get_monitoring_locations() -> pd.DataFrame: 
+    service = "monitoring-locations"
+    output_id = "monitoring_location_id"
 
-#     # Build argument dictionary, omitting None values
-#     args = { 
-#         k: v for k, v in locals().items()
-#         if k not in {"service", "output_id"} and v is not None
-#     }
-#     args["convertType"] = False
+    # Build argument dictionary, omitting None values
+    args = { 
+        k: v for k, v in locals().items()
+        if k not in {"service", "output_id"} and v is not None
+    }
+    args["convertType"] = False
 
-#     return waterdata_helpers.get_ogc_data(args, output_id, service)
+    return waterdata_helpers.get_ogc_data(args, output_id, service)
 
-# def get_ts_meta():
+def get_ts_meta() -> pd.DataFrame:
+    service = "time-series-metadata"
+    output_id = "time_series_id"
 
-# def get_latest_continuous():
+    # Build argument dictionary, omitting None values
+    args = { 
+        k: v for k, v in locals().items()
+        if k not in {"service", "output_id"} and v is not None
+    }
+    args["convertType"] = False
 
-# def get_field_measurements():
+    return waterdata_helpers.get_ogc_data(args, output_id, service)
+
+def get_latest_continuous() -> pd.DataFrame:
+    service = "latest-continuous"
+    output_id = "latest_continuous_id"
+
+    # Build argument dictionary, omitting None values
+    args = { 
+        k: v for k, v in locals().items()
+        if k not in {"service", "output_id"} and v is not None
+    }
+    args["convertType"] = False
+
+    return waterdata_helpers.get_ogc_data(args, output_id, service)
+
+def get_field_measurements() -> pd.DataFrame:
+    service = "field-measurements"
+    output_id = "field_measurement_id"
+
+    # Build argument dictionary, omitting None values
+    args = { 
+        k: v for k, v in locals().items()
+        if k not in {"service", "output_id"} and v is not None
+    }
+    args["convertType"] = False
+
+    return waterdata_helpers.get_ogc_data(args, output_id, service)
  
 def get_codes(code_service: _CODE_SERVICES) -> DataFrame:
     """Return codes from a Samples code service.


### PR DESCRIPTION
This PR will add access to the new water data APIs via the `waterdata` module. 

**CURRENT STATUS 9/19/25**
It is currently a work in progress that appears to work for GET calls in which the user requests one parameter (e.g. site, pcode) at a time. Still working out the POST calls in which a user may request multiple parameters, which requires the use of the CQL2 query language. Stay tuned.