### PR TITLE
Set waterdata data types

### DIFF
--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -165,8 +165,7 @@ def get_daily(
         if your internet connection is spotty. The default (NA) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, converts columns to appropriate types like numeric, datetime,
-        boolean, categorical, etc.
+        If True, converts columns to appropriate types.
 
     Returns
     -------
@@ -476,8 +475,7 @@ def get_monitoring_locations(
         Note that the USGS Water Data APIs use camelCase "skipGeometry" in
         CQL2 queries.
     convert_type : boolean, optional
-        If True, converts columns to appropriate types like numeric, datetime,
-        boolean, categorical, etc.
+        If True, converts columns to appropriate types.
 
     Returns
     -------
@@ -669,8 +667,7 @@ def get_time_series_metadata(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, converts columns to appropriate types like numeric, datetime,
-        boolean, categorical, etc.
+        If True, converts columns to appropriate types.
 
     Returns
     -------
@@ -845,8 +842,7 @@ def get_latest_continuous(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, converts columns to appropriate types like numeric, datetime,
-        boolean, categorical, etc.
+        If True, converts columns to appropriate types.
 
     Returns
     -------
@@ -1020,8 +1016,7 @@ def get_latest_daily(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, converts columns to appropriate types like numeric, datetime,
-        boolean, categorical, etc.
+        If True, converts columns to appropriate types.
 
     Returns
     -------
@@ -1186,8 +1181,7 @@ def get_field_measurements(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, converts columns to appropriate types like numeric, datetime,
-        boolean, categorical, etc.
+        If True, converts columns to appropriate types.
 
     Returns
     -------

--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -165,8 +165,8 @@ def get_daily(
         if your internet connection is spotty. The default (NA) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, the function will convert the data to dates and qualifier to
-        string vector
+        If True, converts columns to appropriate types like numeric, datetime,
+        boolean, categorical, etc.
 
     Returns
     -------
@@ -475,6 +475,9 @@ def get_monitoring_locations(
         The returning object will be a data frame with no spatial information.
         Note that the USGS Water Data APIs use camelCase "skipGeometry" in
         CQL2 queries.
+    convert_type : boolean, optional
+        If True, converts columns to appropriate types like numeric, datetime,
+        boolean, categorical, etc.
 
     Returns
     -------
@@ -666,8 +669,8 @@ def get_time_series_metadata(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, the function will convert the data to dates and qualifier to
-        string vector
+        If True, converts columns to appropriate types like numeric, datetime,
+        boolean, categorical, etc.
 
     Returns
     -------
@@ -842,8 +845,8 @@ def get_latest_continuous(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, the function will convert the data to dates and qualifier to
-        string vector
+        If True, converts columns to appropriate types like numeric, datetime,
+        boolean, categorical, etc.
 
     Returns
     -------
@@ -1017,8 +1020,8 @@ def get_latest_daily(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, the function will convert the data to dates and qualifier to
-        string vector
+        If True, converts columns to appropriate types like numeric, datetime,
+        boolean, categorical, etc.
 
     Returns
     -------
@@ -1183,8 +1186,8 @@ def get_field_measurements(
         if your internet connection is spotty. The default (None) will set the
         limit to the maximum allowable limit for the service.
     convert_type : boolean, optional
-        If True, the function will convert the data to dates and qualifier to
-        string vector
+        If True, converts columns to appropriate types like numeric, datetime,
+        boolean, categorical, etc.
 
     Returns
     -------

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -680,7 +680,7 @@ def _type_cols(df: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        The cleaned DataFrame with standardized columns.
+        The DataFrame with columns cast to appropriate types.
 
     """
     cols = set(df.columns)

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -684,7 +684,7 @@ def _type_cols(df: pd.DataFrame) -> pd.DataFrame:
 
     """
     cols = set(df.columns)
-    numerical_cols = ["value", "contributing_drainage_area"]
+    numerical_cols = ["value", "contributing_drainage_area", "drainage_area", "altitude", "altitude_accuracy", "well_constructed_depth", "hole_constructed_depth"]
     time_cols = ["time", "datetime", "last_modified"]
     categorical_cols = [
         "approval_status",

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -684,8 +684,25 @@ def _type_cols(df: pd.DataFrame) -> pd.DataFrame:
 
     """
     cols = set(df.columns)
-    numerical_cols = ["value", "contributing_drainage_area", "drainage_area", "altitude", "altitude_accuracy", "well_constructed_depth", "hole_constructed_depth"]
-    time_cols = ["time", "datetime", "last_modified"]
+    numerical_cols = [
+        "altitude",
+        "altitude_accuracy",
+        "contributing_drainage_area",
+        "drainage_area",
+        "hole_constructed_depth",
+        "value",
+        "well_constructed_depth",
+        ]
+    time_cols = [
+        "begin",
+        "begin_utc",
+        "construction_date",
+        "end",
+        "end_utc",
+        "datetime", # unused
+        "last_modified",
+        "time",
+        ]
     categorical_cols = [
         "approval_status",
         "monitoring_location_id",

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -703,21 +703,12 @@ def _type_cols(df: pd.DataFrame) -> pd.DataFrame:
         "last_modified",
         "time",
         ]
-    categorical_cols = [
-        "approval_status",
-        "monitoring_location_id",
-        "parameter_code",
-        "unit_of_measure",
-        ]
 
     for col in cols.intersection(time_cols):
         df[col] = pd.to_datetime(df[col], errors="coerce")
 
     for col in cols.intersection(numerical_cols):
         df[col] = pd.to_numeric(df[col], errors="coerce")
-
-    for col in cols.intersection(categorical_cols):
-        df[col] = df[col].astype("category")
 
     return df
 


### PR DESCRIPTION
This is an initial PR to imrove data type handling within the `waterdata` module.
Simply calling `pd.to_datetime(df['time'])` appears to correctly handle daily data.