### PR TITLE
Restrict pandas 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "requests",
-    "pandas==2.*",
+    "pandas>=2.0.0,<3.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Updated pandas dependency constraint from `pandas==2.*` to `pandas>=2.0.0,<3.0.0` to ensure compatibility with conda build tools. The previous constraint syntax was not properly interpreted by conda, potentially allowing pandas 3.x to be installed despite the intent to restrict to version 2.x.