### PR TITLE
Small cleanups: idiomatic Python and a precedence fix

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -96,7 +96,7 @@ def format_response(
     if service == "peaks":
         df = preformat_peaks_response(df)
 
-    if gpd is not None and "dec_lat_va" in list(df):
+    if gpd is not None and "dec_lat_va" in df.columns:
         geoms = gpd.points_from_xy(df.dec_long_va.values, df.dec_lat_va.values)
         df = gpd.GeoDataFrame(df, geometry=geoms, crs=_CRS)
 
@@ -993,9 +993,7 @@ def _read_json(json):
     )
     index_list.append(len(site_list))
 
-    for i in range(len(index_list) - 1):
-        start = index_list[i]  # [0]
-        end = index_list[i + 1]  # [21]
+    for start, end in zip(index_list[:-1], index_list[1:]):
 
         # grab a block containing timeseries 0:21,
         # which are all from the same site

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -994,7 +994,6 @@ def _read_json(json):
     index_list.append(len(site_list))
 
     for start, end in zip(index_list[:-1], index_list[1:]):
-
         # grab a block containing timeseries 0:21,
         # which are all from the same site
         site_block = json["value"]["timeSeries"][start:end]

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -184,9 +184,8 @@ def _format_api_dates(
     if len(datetime_input) <= 2:
         # If the list is of length 1, first look for things like "P7D" or dates
         # already formatted in ISO08601. Otherwise, try to coerce to datetime
-        if (
-            len(datetime_input) == 1
-            and re.search(r"P", datetime_input[0], re.IGNORECASE)
+        if len(datetime_input) == 1 and (
+            re.search(r"P", datetime_input[0], re.IGNORECASE)
             or "/" in datetime_input[0]
         ):
             return datetime_input[0]
@@ -291,12 +290,15 @@ def _check_ogc_requests(endpoint: str = "daily", req_type: str = "queryables"):
 
     Raises
     ------
-    AssertionError
+    ValueError
         If req_type is not "queryables" or "schema".
     requests.HTTPError
         If the HTTP request returns an unsuccessful status code.
     """
-    assert req_type in ["queryables", "schema"]
+    if req_type not in ("queryables", "schema"):
+        raise ValueError(
+            f"req_type must be 'queryables' or 'schema', got {req_type!r}"
+        )
     url = f"{OGC_API_URL}/collections/{endpoint}/{req_type}"
     resp = requests.get(url, headers=_default_headers())
     resp.raise_for_status()

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -296,9 +296,7 @@ def _check_ogc_requests(endpoint: str = "daily", req_type: str = "queryables"):
         If the HTTP request returns an unsuccessful status code.
     """
     if req_type not in ("queryables", "schema"):
-        raise ValueError(
-            f"req_type must be 'queryables' or 'schema', got {req_type!r}"
-        )
+        raise ValueError(f"req_type must be 'queryables' or 'schema', got {req_type!r}")
     url = f"{OGC_API_URL}/collections/{endpoint}/{req_type}"
     resp = requests.get(url, headers=_default_headers())
     resp.raise_for_status()


### PR DESCRIPTION
## Summary
A few small, safe cleanups found during a code review pass. No behavior changes except the precedence fix (#2), which corrects a latent bug.

1. **`waterdata/utils._check_ogc_requests`** — replace runtime `assert req_type in [...]` with an explicit `ValueError`. Assertions can be stripped with `python -O`, so they shouldn't guard user input.
2. **`waterdata/utils._format_datetime`** — fix an operator-precedence bug. The condition
   ```python
   len(datetime_input) == 1 and re.search(r"P", datetime_input[0], ...) or "/" in datetime_input[0]
   ```
   parses as `(A and B) or C`, so a 2-element input whose first element contains `/` would return `datetime_input[0]` and drop the second value. Parenthesized so both branches require `len == 1`.
3. **`nwis.format_response`** — `\"dec_lat_va\" in list(df)` → `in df.columns` (drop needless list construction).
4. **`nwis._read_json` site-block loop** — replace `for i in range(len(index_list) - 1): start, end = index_list[i], index_list[i+1]` with `for start, end in zip(index_list[:-1], index_list[1:])`.

## Test plan
- [ ] CI passes
- [ ] Spot-check `_format_datetime` behavior for 1- and 2-element inputs containing `/`

Other findings from the review (not included here, happy to follow up in separate PRs if wanted): wildcard imports in `__init__.py`, several `inplace=True` pandas calls, commented-out dead code in `nadp.py`/`streamstats.py`/`nldi.py`, stub `pass` branches in `streamstats.format_response`, and missing context managers around `requests.get` + `ZipFile` in `nadp.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)