### PR TITLE
Use PEP 639 SPDX license identifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ description = "Discover and retrieve water data from U.S. federal hydrologic web
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["USGS", "water data"]
-license = {file = "LICENSE.md"}
+license = "CC0-1.0"
+license-files = ["LICENSE.md"]
 authors = [
   {name = "Timothy Hodson", email = "thodson@usgs.gov"},
 ]


### PR DESCRIPTION
## Summary

- Replaces `license = {file = "LICENSE.md"}` with the [PEP 639](https://peps.python.org/pep-0639/) SPDX identifier syntax: `license = "CC0-1.0"` + `license-files = ["LICENSE.md"]`

This is a rebase of @davetapley's original change in #187 onto current `main`. The prior PR had CI failures on Python 3.8, but 3.8 has since been dropped from the test matrix, so those failures no longer apply. The change itself is correct and unmodified.

Closes #187.

## Test plan

- [ ] CI passes (3.8 jobs no longer exist in the matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)