### PR TITLE
Fix IndexError in _read_rdb when NWIS returns no data rows

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -1039,8 +1039,9 @@ def _read_rdb(rdb):
         )
 
     count = 0
+    lines = rdb.splitlines()
 
-    for line in rdb.splitlines():
+    for line in lines:
         # ignore comment lines
         if line.startswith("#"):
             count = count + 1
@@ -1048,7 +1049,16 @@ def _read_rdb(rdb):
         else:
             break
 
-    fields = rdb.splitlines()[count].split("\t")
+    if count >= len(lines):
+        # All lines are comments — no data rows. Extract the NWIS message.
+        msg = "No data returned from the NWIS service."
+        for line in lines:
+            if "Response-Message:" in line:
+                msg = line.split("Response-Message:")[-1].strip()
+                break
+        raise ValueError(msg)
+
+    fields = lines[count].split("\t")
     fields = [field.replace(",", "").strip() for field in fields if field.strip()]
     dtypes = {
         "site_no": str,

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -1050,13 +1050,10 @@ def _read_rdb(rdb):
             break
 
     if count >= len(lines):
-        # All lines are comments — no data rows. Extract the NWIS message.
-        msg = "No data returned from the NWIS service."
-        for line in lines:
-            if "Response-Message:" in line:
-                msg = line.split("Response-Message:")[-1].strip()
-                break
-        raise ValueError(msg)
+        # All lines are comments — the service returned no data rows (e.g.
+        # "No sites found matching all criteria").  This is a legitimate empty
+        # result, so return an empty DataFrame rather than raising.
+        return pd.DataFrame()
 
     fields = lines[count].split("\t")
     fields = [field.replace(",", "").strip() for field in fields if field.strip()]

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -333,12 +333,7 @@ class TestReadRdb:
     """
 
     # Minimal valid RDB response with one data row
-    _VALID_RDB = (
-        "# comment\n"
-        "site_no\tvalue\n"
-        "5s\t10n\n"
-        "01491000\t42\n"
-    )
+    _VALID_RDB = "# comment\nsite_no\tvalue\n5s\t10n\n01491000\t42\n"
 
     # NWIS response when no sites match the query criteria
     _NO_SITES_RDB = (
@@ -353,13 +348,20 @@ class TestReadRdb:
         assert isinstance(df, pd.DataFrame)
         assert "site_no" in df.columns
 
-    def test_no_sites_raises_value_error(self):
-        """_read_rdb raises ValueError when NWIS returns no data rows (issue #171)."""
-        with pytest.raises(ValueError, match="No sites found"):
-            _read_rdb(self._NO_SITES_RDB)
+    def test_no_sites_returns_empty_dataframe(self):
+        """_read_rdb returns an empty DataFrame when NWIS finds no matching sites.
 
-    def test_empty_comments_raises_value_error(self):
-        """_read_rdb raises a generic ValueError when response has only comments."""
+        A "No sites found" response is a legitimate empty result, not an error,
+        so callers can check ``df.empty`` rather than catching an exception.
+        Regression test for issue #171 (previously raised IndexError).
+        """
+        df = _read_rdb(self._NO_SITES_RDB)
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_all_comments_returns_empty_dataframe(self):
+        """_read_rdb returns an empty DataFrame when the response has only comments."""
         rdb = "# just a comment\n# another comment\n"
-        with pytest.raises(ValueError):
-            _read_rdb(rdb)
+        df = _read_rdb(rdb)
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty

--- a/tests/nwis_test.py
+++ b/tests/nwis_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from dataretrieval.nwis import (
     NWIS_Metadata,
+    _read_rdb,
     get_discharge_measurements,
     get_gwlevels,
     get_info,
@@ -321,3 +322,44 @@ class TestMetaData:
         ):
             result = md.variable_info
         assert result is None
+
+
+class TestReadRdb:
+    """Tests for the _read_rdb helper.
+
+    Notes
+    -----
+    Related to GitHub Issue #171.
+    """
+
+    # Minimal valid RDB response with one data row
+    _VALID_RDB = (
+        "# comment\n"
+        "site_no\tvalue\n"
+        "5s\t10n\n"
+        "01491000\t42\n"
+    )
+
+    # NWIS response when no sites match the query criteria
+    _NO_SITES_RDB = (
+        "# //Output-Format: RDB\n"
+        "# //Response-Status: OK\n"
+        "# //Response-Message: No sites found matching all criteria\n"
+    )
+
+    def test_valid_rdb_returns_dataframe(self):
+        """_read_rdb returns a DataFrame for a well-formed RDB response."""
+        df = _read_rdb(self._VALID_RDB)
+        assert isinstance(df, pd.DataFrame)
+        assert "site_no" in df.columns
+
+    def test_no_sites_raises_value_error(self):
+        """_read_rdb raises ValueError when NWIS returns no data rows (issue #171)."""
+        with pytest.raises(ValueError, match="No sites found"):
+            _read_rdb(self._NO_SITES_RDB)
+
+    def test_empty_comments_raises_value_error(self):
+        """_read_rdb raises a generic ValueError when response has only comments."""
+        rdb = "# just a comment\n# another comment\n"
+        with pytest.raises(ValueError):
+            _read_rdb(rdb)


### PR DESCRIPTION
## Summary

Fixes #171.

When the NWIS stats service has no data for a site, it returns a valid HTTP 200 with only comment lines:

```
# //Output-Format: RDB
# //Response-Status: OK
# //Response-Message: No sites found matching all criteria
```

`_read_rdb` tried to index `lines[count]` for field names after counting comment lines, but with no data rows `count == len(lines)`, causing an unhelpful `IndexError`.

Since this is a legitimate empty result (not an error), the fix returns an empty `DataFrame` so callers can use the idiomatic `df.empty` check:

```python
df, md = nwis.get_stats(sites="02469675")
if df.empty:
    print("No data for this site")
```

## Test plan

- [x] `TestReadRdb::test_no_sites_returns_empty_dataframe` — uses the exact response body from the live endpoint (`https://waterservices.usgs.gov/nwis/stat/?sites=02469675`)
- [x] `TestReadRdb::test_all_comments_returns_empty_dataframe` — generic all-comments case
- [x] `TestReadRdb::test_valid_rdb_returns_dataframe` — regression: normal responses still parse correctly
- [x] Full `tests/nwis_test.py` suite passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)