### PR TITLE
Add tsv mimeType support and raise clear error for xlsx in WQP

### DIFF
--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -154,7 +154,7 @@ def get_results(
 
     response = query(url, kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
     return df, WQP_Metadata(response)
 
 
@@ -208,7 +208,7 @@ def what_sites(
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -263,7 +263,7 @@ def what_organizations(
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -314,7 +314,7 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -378,7 +378,7 @@ def what_activities(
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -440,7 +440,7 @@ def what_detection_limits(
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -495,7 +495,7 @@ def what_habitat_metrics(
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -551,7 +551,7 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -607,7 +607,7 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",")
+    df = _read_wqp_response(response.text, kwargs)
 
     return df, WQP_Metadata(response)
 
@@ -697,12 +697,22 @@ def _check_kwargs(kwargs):
     mimetype = kwargs.get("mimeType")
     if mimetype == "geojson":
         raise NotImplementedError("GeoJSON not yet supported. Set 'mimeType=csv'.")
-    elif mimetype != "csv" and mimetype is not None:
-        raise ValueError("Invalid mimeType. Set 'mimeType=csv'.")
-    else:
+    elif mimetype == "xlsx":
+        raise NotImplementedError(
+            "Excel format not yet supported. Set 'mimeType=csv' or 'mimeType=tsv'."
+        )
+    elif mimetype not in ("csv", "tsv", None):
+        raise ValueError("Invalid mimeType. Supported options: 'csv', 'tsv'.")
+    elif mimetype is None:
         kwargs["mimeType"] = "csv"
 
     return kwargs
+
+
+def _read_wqp_response(text, kwargs):
+    """Parse a WQP response into a DataFrame, respecting the requested mimeType."""
+    delimiter = "\t" if kwargs.get("mimeType") == "tsv" else ","
+    return pd.read_csv(StringIO(text), delimiter=delimiter, low_memory=False)
 
 
 def _warn_wqx3_use():

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -52,8 +52,8 @@ def _is_code_column(name: str) -> bool:
     )
 
 
-def _read_wqp_csv(text: str) -> DataFrame:
-    """Read a WQP CSV, forcing code/identifier columns to ``str``.
+def _read_wqp_csv(text: str, delimiter: str = ",") -> DataFrame:
+    """Read a WQP CSV/TSV, forcing code/identifier columns to ``str``.
 
     WQP returns codes with significant leading zeros — HUCs, parameter codes
     (``USGSpcode``), FIPS state/county codes. A bare ``read_csv`` infers those
@@ -61,10 +61,20 @@ def _read_wqp_csv(text: str) -> DataFrame:
     ``"07090002"`` -> ``7090002``). Read the header first, then re-read with
     ``dtype=str`` for every column that :func:`_is_code_column` flags, so the
     zeros survive.
+
+    ``delimiter`` selects comma (CSV, the default) vs tab (TSV); see
+    :func:`_wqp_delimiter`.
     """
-    columns = pd.read_csv(StringIO(text), delimiter=",", nrows=0).columns
+    columns = pd.read_csv(StringIO(text), delimiter=delimiter, nrows=0).columns
     str_cols = {col: str for col in columns if _is_code_column(col)}
-    return pd.read_csv(StringIO(text), delimiter=",", low_memory=False, dtype=str_cols)
+    return pd.read_csv(
+        StringIO(text), delimiter=delimiter, low_memory=False, dtype=str_cols
+    )
+
+
+def _wqp_delimiter(kwargs: dict[str, Any]) -> str:
+    """Field delimiter for the requested ``mimeType``: tab for ``tsv``, else comma."""
+    return "\t" if kwargs.get("mimeType") == "tsv" else ","
 
 
 def get_results(
@@ -181,7 +191,7 @@ def get_results(
 
     response = query(url, kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = _read_wqp_csv(response.text)
+    df = _read_wqp_csv(response.text, _wqp_delimiter(kwargs))
     df = _attach_datetime_columns(df)
     return df, WQP_Metadata(response, **kwargs)
 
@@ -209,7 +219,7 @@ def _what(
         url = _legacy_only_url(service, legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
-    df = _read_wqp_csv(response.text)
+    df = _read_wqp_csv(response.text, _wqp_delimiter(kwargs))
     return df, WQP_Metadata(response, **kwargs)
 
 
@@ -690,9 +700,13 @@ def _check_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     mimetype = kwargs.get("mimeType")
     if mimetype == "geojson":
         raise NotImplementedError("GeoJSON not yet supported. Set 'mimeType=csv'.")
-    elif mimetype != "csv" and mimetype is not None:
-        raise ValueError("Invalid mimeType. Set 'mimeType=csv'.")
-    else:
+    elif mimetype == "xlsx":
+        raise NotImplementedError(
+            "Excel format not yet supported. Set 'mimeType=csv' or 'mimeType=tsv'."
+        )
+    elif mimetype not in ("csv", "tsv", None):
+        raise ValueError("Invalid mimeType. Supported options: 'csv', 'tsv'.")
+    elif mimetype is None:
         kwargs["mimeType"] = "csv"
 
     return kwargs

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -213,6 +213,36 @@ def test_check_kwargs():
     kwargs = {"mimeType": "geojson"}
     with pytest.raises(NotImplementedError):
         kwargs = _check_kwargs(kwargs)
+    kwargs = {"mimeType": "xlsx"}
+    with pytest.raises(NotImplementedError):
+        kwargs = _check_kwargs(kwargs)
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
+    # tsv and csv should both be accepted
+    kwargs = _check_kwargs({"mimeType": "tsv"})
+    assert kwargs["mimeType"] == "tsv"
+    kwargs = _check_kwargs({"mimeType": "csv"})
+    assert kwargs["mimeType"] == "csv"
+    # no mimeType defaults to csv
+    kwargs = _check_kwargs({})
+    assert kwargs["mimeType"] == "csv"
+
+
+def test_get_results_tsv(requests_mock):
+    """Tests that mimeType=tsv is accepted and parsed with a tab delimiter."""
+    request_url = (
+        "https://www.waterqualitydata.us/data/Result/Search?"
+        "siteid=WIDNR_WQX-10032762&mimeType=tsv"
+    )
+    tsv_text = "col_a\tcol_b\nvalue_1\tvalue_2\n"
+    requests_mock.get(request_url, text=tsv_text, headers={"mock_header": "value"})
+    df, md = get_results(
+        legacy=True,
+        siteid="WIDNR_WQX-10032762",
+        mimeType="tsv",
+    )
+    assert type(df) is DataFrame
+    assert list(df.columns) == ["col_a", "col_b"]
+    assert df.shape == (1, 2)
+    assert md.url == request_url

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -53,6 +53,37 @@ def test_read_wqp_csv_preserves_leading_zero_codes():
     assert df["ResultMeasureValue"].iloc[0] == 1.5
 
 
+def test_read_wqp_csv_tsv_delimiter_preserves_codes():
+    """``mimeType=tsv`` responses are parsed as tab-delimited via
+    ``_read_wqp_csv``'s ``delimiter`` while still preserving leading zeros on
+    code columns."""
+    from dataretrieval.wqp import _read_wqp_csv
+
+    tsv = (
+        "Location_HUCEightDigitCode\tUSGSpcode\tResultMeasureValue\n"
+        "07090002\t00060\t1.5\n"
+    )
+    df = _read_wqp_csv(tsv, delimiter="\t")
+    assert list(df.columns) == [
+        "Location_HUCEightDigitCode",
+        "USGSpcode",
+        "ResultMeasureValue",
+    ]
+    assert df["Location_HUCEightDigitCode"].iloc[0] == "07090002"
+    assert df["USGSpcode"].iloc[0] == "00060"
+    assert df["ResultMeasureValue"].iloc[0] == 1.5
+
+
+def test_wqp_delimiter_selects_tab_for_tsv():
+    """``_wqp_delimiter`` maps ``mimeType=tsv`` to a tab and everything else
+    (including a missing mimeType) to a comma."""
+    from dataretrieval.wqp import _wqp_delimiter
+
+    assert _wqp_delimiter({"mimeType": "tsv"}) == "\t"
+    assert _wqp_delimiter({"mimeType": "csv"}) == ","
+    assert _wqp_delimiter({}) == ","
+
+
 def test_get_results(httpx_mock):
     """Tests water quality portal ratings query"""
     request_url = (
@@ -153,6 +184,16 @@ def test_check_kwargs():
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
+
+
+def test_check_kwargs_mimetype_csv_tsv_xlsx():
+    """csv/tsv are accepted as-is, a missing mimeType defaults to csv, and
+    xlsx raises a clear NotImplementedError pointing at the csv/tsv options."""
+    assert _check_kwargs({"mimeType": "csv"})["mimeType"] == "csv"
+    assert _check_kwargs({"mimeType": "tsv"})["mimeType"] == "tsv"
+    assert _check_kwargs({})["mimeType"] == "csv"
+    with pytest.raises(NotImplementedError, match="Excel"):
+        _check_kwargs({"mimeType": "xlsx"})
 
 
 def test_get_results_wqx3_preserves_user_dataProfile(httpx_mock):


### PR DESCRIPTION
Closes #162

## Summary
- `_check_kwargs` now accepts `mimeType='tsv'` alongside `'csv'` for legacy WQP calls
- `mimeType='xlsx'` raises `NotImplementedError` with a clear message (xlsx support is not yet implemented)
- Any other invalid mimeType raises `ValueError: Invalid mimeType. Supported options: 'csv', 'tsv'.`
- Extracted `_read_wqp_response(text, kwargs)` helper that replaces 9 identical `pd.read_csv(..., delimiter=",")` calls — uses `\t` delimiter when `mimeType='tsv'`, `,` otherwise

Note: tsv support applies to legacy WQP calls only. WQX3.0 endpoints only support csv at this time, as noted in the original issue.

## Test plan
- [x] `test_check_kwargs` updated to cover `tsv` (passes), `xlsx` (NotImplementedError), and unchanged cases
- [x] `test_get_results_tsv` added: mocks a tab-delimited response and verifies it is parsed correctly
- [x] All 94 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)