### PR TITLE
Deprecate nadp module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+**05/01/2026:** The `nadp` module is now deprecated. Calling any of `get_annual_MDN_map`, `get_annual_NTN_map`, or `get_zip` will emit a `DeprecationWarning`. The module is scheduled for removal on or after **2026-11-01**. NADP is not a USGS data source; users should retrieve NADP data directly from https://nadp.slh.wisc.edu/.
+
 **04/23/2026:** Added `waterdata.get_nearest_continuous(targets, ...)` — for each of N target timestamps, fetches the single continuous observation closest to that timestamp in one HTTP round-trip (auto-chunked when the resulting CQL filter is long, via the facility added in #238). The helper is designed for workflows that pair many discrete-measurement timestamps with surrounding instantaneous data, which the OGC `time` parameter can't express since it only accepts one instant or one interval per request. Ties at window midpoints are resolved per a configurable `on_tie` ∈ {`"first"`, `"last"`, `"mean"`}; the default `window="PT7M30S"` matches a 15-minute continuous gauge.
 
 **04/22/2026:** Highlights since the `v1.1.0` release (2025-11-26), which shipped the `waterdata` module:

--- a/dataretrieval/nadp.py
+++ b/dataretrieval/nadp.py
@@ -31,9 +31,21 @@ the data as a GDAL memory-mapped file when no path is specified.
 
 import io
 import re
+import warnings
 import zipfile
 
 import requests
+
+_DEPRECATION_MESSAGE = (
+    "The `nadp` module is deprecated and will be removed from `dataretrieval` "
+    "on or after 2026-11-01. NADP is not a USGS data source; please retrieve "
+    "NADP data directly from https://nadp.slh.wisc.edu/."
+)
+
+
+def _warn_deprecated():
+    warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
+
 
 NADP_URL = "https://nadp.slh.wisc.edu"
 NADP_MAP_EXT = "filelib/maps"
@@ -107,6 +119,8 @@ def get_annual_MDN_map(measurement_type, year, path):
         ... )
 
     """
+    _warn_deprecated()
+
     url = f"{NADP_URL}/{NADP_MAP_EXT}/MDN/grids/"
 
     filename = f"Hg_{measurement_type}_{year}.zip"
@@ -160,6 +174,8 @@ def get_annual_NTN_map(measurement_type, measurement=None, year=None, path="."):
         ... )
 
     """
+    _warn_deprecated()
+
     url = f"{NADP_URL}/{NADP_MAP_EXT}/NTN/grids/{year}/"
 
     filename = f"{measurement_type}_{year}.zip"
@@ -195,6 +211,8 @@ def get_zip(url, filename):
         finish docstring
 
     """
+    _warn_deprecated()
+
     req = requests.get(url + filename)
     req.raise_for_status()
 


### PR DESCRIPTION
## Summary

- Adds a `DeprecationWarning` to every public function in `dataretrieval.nadp` (`get_annual_MDN_map`, `get_annual_NTN_map`, `get_zip`).
- The warning notes the scheduled removal date of **2026-11-01** (six months from this deprecation) and points users to retrieve NADP data directly from https://nadp.slh.wisc.edu/.
- Adds a NEWS.md entry.

Tracking issue with full justification and timeline: #244.

## Test plan

- [x] `python3 -c "import dataretrieval.nadp; ..."` confirms each of the three public functions raises `DeprecationWarning` with the expected message.
- [x] Existing `tests/nadp_test.py` should continue to pass (warnings are emitted but not errors); CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)