### PR TITLE
Fix Watershed class: persist instance state and parse JSON

### DIFF
--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -136,26 +136,47 @@ def get_watershed(
         # use Fiona to return a shape object
         pass
 
-    if format == "object":
-        # return a python object
-        pass
-
     data = json.loads(r.text)
+
+    if format == "object":
+        return data
+
     return Watershed.from_streamstats_json(data)
 
 
 class Watershed:
-    """Class to extract information from the streamstats JSON object."""
+    """Class to extract information from the streamstats JSON object.
+
+    Attributes
+    ----------
+    watershed_point : dict
+        GeoJSON feature for the watershed pour point.
+    watershed_polygon : dict
+        GeoJSON feature for the delineated watershed polygon.
+    parameters : list
+        Watershed parameters returned by StreamStats.
+    workspace_id : str
+        StreamStats workspace identifier for the watershed.
+    """
+
+    def __init__(self, rcode, xlocation, ylocation):
+        """Delineate a watershed and populate the instance from the response."""
+        data = get_watershed(rcode, xlocation, ylocation, format="object")
+        self._populate_from_json(data)
 
     @classmethod
     def from_streamstats_json(cls, streamstats_json):
-        """Method that creates a Watershed object from a streamstats JSON."""
-        cls.watershed_point = streamstats_json["featurecollection"][0]["feature"]
-        cls.watershed_polygon = streamstats_json["featurecollection"][1]["feature"]
-        cls.parameters = streamstats_json["parameters"]
-        cls._workspaceID = streamstats_json["workspaceID"]
-        return cls
+        """Construct a :obj:`Watershed` from a StreamStats JSON response."""
+        instance = cls.__new__(cls)
+        instance._populate_from_json(streamstats_json)
+        return instance
 
-    def __init__(self, rcode, xlocation, ylocation):
-        """Init method that calls the :obj:`from_streamstats_json` method."""
-        get_watershed(rcode, xlocation, ylocation)
+    def _populate_from_json(self, streamstats_json):
+        self.watershed_point = streamstats_json["featurecollection"][0]["feature"]
+        self.watershed_polygon = streamstats_json["featurecollection"][1]["feature"]
+        self.parameters = streamstats_json["parameters"]
+        self.workspace_id = streamstats_json["workspaceID"]
+
+    @property
+    def _workspaceID(self):
+        return self.workspace_id

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -5,6 +5,8 @@ This module is a wrapper for the streamstats API (`streamstats documentation`_).
 
 """
 
+import warnings
+
 import requests
 
 
@@ -182,4 +184,10 @@ class Watershed:
 
     @property
     def _workspaceID(self):
+        """Deprecated alias for ``workspace_id``."""
+        warnings.warn(
+            "Watershed._workspaceID is deprecated; use workspace_id instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.workspace_id

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -5,8 +5,6 @@ This module is a wrapper for the streamstats API (`streamstats documentation`_).
 
 """
 
-import json
-
 import requests
 
 
@@ -137,11 +135,7 @@ def get_watershed(
     if format == "geojson":
         return r
 
-    if format == "shape":
-        # use Fiona to return a shape object
-        pass
-
-    data = json.loads(r.text)
+    data = r.json()
 
     if format == "object":
         return data

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -56,7 +56,7 @@ def get_sample_watershed():
         from the streamstats JSON object.
 
     """
-    return get_watershed("NY", -74.524, 43.939)
+    return get_watershed("NY", -74.524, 43.939, format="watershed")
 
 
 def get_watershed(
@@ -106,8 +106,8 @@ def get_watershed(
     format: string, optional
         Selects the return shape. ``"geojson"`` (default) returns the raw
         ``requests.Response``; ``"object"`` returns the parsed JSON ``dict``;
-        any other value returns a :obj:`Watershed` instance built from the
-        parsed JSON.
+        ``"watershed"`` returns a :obj:`Watershed` instance built from the
+        parsed JSON. Any other value raises ``ValueError``.
 
     Returns
     -------
@@ -140,7 +140,12 @@ def get_watershed(
     if format == "object":
         return data
 
-    return Watershed.from_streamstats_json(data)
+    if format == "watershed":
+        return Watershed.from_streamstats_json(data)
+
+    raise ValueError(
+        f"Invalid format {format!r}; expected 'geojson', 'object', or 'watershed'."
+    )
 
 
 class Watershed:

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -70,14 +70,13 @@ def get_watershed(
     simplify=True,
     format="geojson",
 ):
-    """Get watershed object based on location
+    """Delineate a watershed via the StreamStats API.
 
-    **Streamstats documentation:**
-    Returns a watershed object. The request configuration will determine the
-    overall request response. However all returns will return a watershed
-    object with at least the workspaceid. The workspace id is the id to the
-    service workspace where files are stored and can be used for further
-    processing such as for downloads and flow statistic computations.
+    Hits the StreamStats ``watershed.geojson`` endpoint and returns the
+    delineated watershed in one of three shapes selected by ``format``: the
+    raw ``requests.Response`` (default), the parsed JSON ``dict``, or a
+    :obj:`Watershed` instance. Every response carries a workspace identifier
+    that can be passed to :obj:`download_workspace` for further processing.
 
     See: https://streamstats.usgs.gov/streamstatsservices/#/ for more
     information.

--- a/dataretrieval/streamstats.py
+++ b/dataretrieval/streamstats.py
@@ -105,12 +105,17 @@ def get_watershed(
     simplify: bool, optional
         Boolean flag controlling whether or not to simplify the returned
         result.
+    format: string, optional
+        Selects the return shape. ``"geojson"`` (default) returns the raw
+        ``requests.Response``; ``"object"`` returns the parsed JSON ``dict``;
+        any other value returns a :obj:`Watershed` instance built from the
+        parsed JSON.
 
     Returns
     -------
-    Watershed: :obj:`dataretrieval.streamstats.Watershed`
-        Custom object that contains the watershed information as extracted
-        from the streamstats JSON object.
+    requests.Response, dict, or :obj:`dataretrieval.streamstats.Watershed`
+        Watershed information from StreamStats. The exact return type
+        depends on ``format`` (see above).
 
     """
     payload = {

--- a/tests/streamstats_test.py
+++ b/tests/streamstats_test.py
@@ -1,6 +1,11 @@
 """Tests for the streamstats module."""
 
-from dataretrieval.streamstats import Watershed
+from unittest import mock
+
+import pytest
+
+from dataretrieval import streamstats
+from dataretrieval.streamstats import Watershed, get_watershed
 
 SAMPLE_JSON = {
     "featurecollection": [
@@ -31,3 +36,45 @@ def test_from_streamstats_json_does_not_mutate_class():
     assert w2.parameters[0]["code"] == "OTHER"
     assert w1.watershed_point["id"] == "pt-1"
     assert w2.watershed_point["id"] == "pt-2"
+
+
+def test_from_streamstats_json_returns_watershed_instance():
+    """Regression: previously returned the class itself, not an instance."""
+    w = Watershed.from_streamstats_json(SAMPLE_JSON)
+    assert isinstance(w, Watershed)
+
+
+def test_workspaceID_alias_emits_deprecation_warning():
+    """`_workspaceID` mirrors `workspace_id` but signals migration."""
+    w = Watershed.from_streamstats_json(SAMPLE_JSON)
+    with pytest.warns(DeprecationWarning, match="workspace_id"):
+        assert w._workspaceID == w.workspace_id
+
+
+@pytest.fixture
+def patched_get(monkeypatch):
+    """Stub ``requests.get`` so format-dispatch tests stay offline."""
+    response = mock.MagicMock()
+    response.json.return_value = SAMPLE_JSON
+    response.raise_for_status.return_value = None
+    monkeypatch.setattr(streamstats.requests, "get", lambda *a, **kw: response)
+    return response
+
+
+def test_get_watershed_object_returns_dict(patched_get):
+    """Regression: pre-fix this branch was a `pass` and returned None."""
+    result = get_watershed("NY", -74.524, 43.939, format="object")
+    assert result == SAMPLE_JSON
+
+
+def test_get_watershed_watershed_returns_instance(patched_get):
+    """`format='watershed'` builds a Watershed from the parsed JSON."""
+    result = get_watershed("NY", -74.524, 43.939, format="watershed")
+    assert isinstance(result, Watershed)
+    assert result.workspace_id == SAMPLE_JSON["workspaceID"]
+
+
+def test_get_watershed_unknown_format_raises(patched_get):
+    """Unknown `format` is rejected; pre-fix it silently fell through."""
+    with pytest.raises(ValueError, match="Invalid format"):
+        get_watershed("NY", -74.524, 43.939, format="bogus")

--- a/tests/streamstats_test.py
+++ b/tests/streamstats_test.py
@@ -1,0 +1,69 @@
+"""Tests for the streamstats module."""
+
+import json
+
+from dataretrieval.streamstats import Watershed, get_watershed
+
+SAMPLE_JSON = {
+    "featurecollection": [
+        {"name": "globalwatershedpoint", "feature": {"type": "Feature", "id": "pt-1"}},
+        {"name": "globalwatershed", "feature": {"type": "Feature", "id": "poly-1"}},
+    ],
+    "parameters": [{"code": "DRNAREA", "value": 41.2}],
+    "workspaceID": "NY20240101000000000",
+}
+
+
+def test_from_streamstats_json_returns_instance():
+    """Watershed.from_streamstats_json must return an instance, not the class."""
+    w = Watershed.from_streamstats_json(SAMPLE_JSON)
+    assert isinstance(w, Watershed)
+
+
+def test_from_streamstats_json_does_not_mutate_class():
+    """Two watersheds must not share state via class-level attributes."""
+    other_json = {
+        "featurecollection": [
+            {"feature": {"id": "pt-2"}},
+            {"feature": {"id": "poly-2"}},
+        ],
+        "parameters": [{"code": "OTHER", "value": 1.0}],
+        "workspaceID": "VT20240101000000000",
+    }
+    w1 = Watershed.from_streamstats_json(SAMPLE_JSON)
+    w2 = Watershed.from_streamstats_json(other_json)
+
+    assert w1.workspace_id == "NY20240101000000000"
+    assert w2.workspace_id == "VT20240101000000000"
+    assert w1.parameters[0]["code"] == "DRNAREA"
+    assert w2.parameters[0]["code"] == "OTHER"
+    assert w1.watershed_point["id"] == "pt-1"
+    assert w2.watershed_point["id"] == "pt-2"
+
+
+def test_get_watershed_object_returns_dict(requests_mock):
+    """get_watershed(format='object') must return parsed JSON, not None."""
+    url = "https://streamstats.usgs.gov/streamstatsservices/watershed.geojson"
+    requests_mock.get(url, text=json.dumps(SAMPLE_JSON))
+
+    result = get_watershed("NY", -74.524, 43.939, format="object")
+    assert isinstance(result, dict)
+    assert result["workspaceID"] == "NY20240101000000000"
+
+
+def test_watershed_init_populates_instance(requests_mock):
+    """Watershed(...) must populate the instance (regression: previously discarded)."""
+    url = "https://streamstats.usgs.gov/streamstatsservices/watershed.geojson"
+    requests_mock.get(url, text=json.dumps(SAMPLE_JSON))
+
+    w = Watershed("NY", -74.524, 43.939)
+    assert w.workspace_id == "NY20240101000000000"
+    assert w.parameters[0]["code"] == "DRNAREA"
+    assert w.watershed_point["id"] == "pt-1"
+    assert w.watershed_polygon["id"] == "poly-1"
+
+
+def test_workspace_id_back_compat_alias():
+    """Legacy `_workspaceID` attribute should still resolve."""
+    w = Watershed.from_streamstats_json(SAMPLE_JSON)
+    assert w._workspaceID == w.workspace_id == "NY20240101000000000"

--- a/tests/streamstats_test.py
+++ b/tests/streamstats_test.py
@@ -1,8 +1,6 @@
 """Tests for the streamstats module."""
 
-import json
-
-from dataretrieval.streamstats import Watershed, get_watershed
+from dataretrieval.streamstats import Watershed
 
 SAMPLE_JSON = {
     "featurecollection": [
@@ -12,12 +10,6 @@ SAMPLE_JSON = {
     "parameters": [{"code": "DRNAREA", "value": 41.2}],
     "workspaceID": "NY20240101000000000",
 }
-
-
-def test_from_streamstats_json_returns_instance():
-    """Watershed.from_streamstats_json must return an instance, not the class."""
-    w = Watershed.from_streamstats_json(SAMPLE_JSON)
-    assert isinstance(w, Watershed)
 
 
 def test_from_streamstats_json_does_not_mutate_class():
@@ -39,31 +31,3 @@ def test_from_streamstats_json_does_not_mutate_class():
     assert w2.parameters[0]["code"] == "OTHER"
     assert w1.watershed_point["id"] == "pt-1"
     assert w2.watershed_point["id"] == "pt-2"
-
-
-def test_get_watershed_object_returns_dict(requests_mock):
-    """get_watershed(format='object') must return parsed JSON, not None."""
-    url = "https://streamstats.usgs.gov/streamstatsservices/watershed.geojson"
-    requests_mock.get(url, text=json.dumps(SAMPLE_JSON))
-
-    result = get_watershed("NY", -74.524, 43.939, format="object")
-    assert isinstance(result, dict)
-    assert result["workspaceID"] == "NY20240101000000000"
-
-
-def test_watershed_init_populates_instance(requests_mock):
-    """Watershed(...) must populate the instance (regression: previously discarded)."""
-    url = "https://streamstats.usgs.gov/streamstatsservices/watershed.geojson"
-    requests_mock.get(url, text=json.dumps(SAMPLE_JSON))
-
-    w = Watershed("NY", -74.524, 43.939)
-    assert w.workspace_id == "NY20240101000000000"
-    assert w.parameters[0]["code"] == "DRNAREA"
-    assert w.watershed_point["id"] == "pt-1"
-    assert w.watershed_polygon["id"] == "poly-1"
-
-
-def test_workspace_id_back_compat_alias():
-    """Legacy `_workspaceID` attribute should still resolve."""
-    w = Watershed.from_streamstats_json(SAMPLE_JSON)
-    assert w._workspaceID == w.workspace_id == "NY20240101000000000"


### PR DESCRIPTION
## Summary
- `Watershed.from_streamstats_json` was a classmethod that mutated `cls` instead of building an instance, causing every watershed to share class-level state and the method to return the class itself rather than a `Watershed`.
- `Watershed.__init__(rcode, x, y)` called `get_watershed(...)` and discarded the result, so a freshly-constructed instance had no attributes of its own.
- `get_watershed(format="object")` returned `None` instead of the parsed JSON dict its docstring promised.

This PR makes `from_streamstats_json` return a real instance, makes `__init__` populate `self` via `get_watershed(format="object")`, and makes `format="object"` actually return the parsed JSON. The legacy `_workspaceID` attribute is preserved as a read-only alias for the new `workspace_id`.

While here:
- Dropped the dead `format == "shape"` branch (a stale Fiona-stub `pass` that fell through to a `Watershed` despite documenting a different return type).
- Made the `format` contract explicit: added a `"watershed"` case alongside `"geojson"`/`"object"`, and unrecognized values now raise `ValueError`. Previously any unrecognized format silently fell through to a `Watershed` — the same bug shape that masked the broken `"shape"` branch.
- Fixed `get_sample_watershed` to actually return a `Watershed` instance (preexisting docstring/behavior mismatch — it called `get_watershed(...)` with the default `format="geojson"` and so returned the raw `Response`).
- Switched `json.loads(r.text)` to `r.json()` to match the convention used in `nldi.py`/`nwis.py`.
- Rewrote the `get_watershed` narrative docstring to describe the multi-return contract (`Response` / `dict` / `Watershed` selected by `format`) instead of the previous "always returns a watershed" wording, which contradicted the actual default behavior.

## Minimal reproducible examples

Reconstructed inline because the live StreamStats endpoint is currently returning 404 across requests; the bug shapes are pure-Python and don't depend on the API.

### Bug 1: `from_streamstats_json` mutates the class

```python
class BuggyWatershed:
    @classmethod
    def from_streamstats_json(cls, blob):
        cls.workspace_id = blob["workspaceID"]   # mutates the class
        cls.parameters = blob["parameters"]
        return cls                                # returns the class itself

a = BuggyWatershed.from_streamstats_json({"workspaceID": "WS_A", "parameters": ["a"]})
b = BuggyWatershed.from_streamstats_json({"workspaceID": "WS_B", "parameters": ["b"]})
print(a is BuggyWatershed)                       # True — not an instance!
print(a.workspace_id, b.workspace_id)            # WS_B WS_B — shared class-level state
```

### Bug 2: `__init__` discards the work

```python
class BuggyWatershed:
    def __init__(self, rcode, x, y):
        _ = get_watershed(rcode, x, y)            # result discarded

ws = BuggyWatershed("MA", -72.7, 42.6)
print(hasattr(ws, "workspace_id"))                # False
```

### Bug 3: `format="object"` returns `None`

```python
def buggy_get_watershed(rcode, x, y, format="geojson"):
    if format == "geojson":
        return _response
    elif format == "object":
        pass                                      # implicit None
```

After this PR, `format="object"` returns the parsed `dict`, `Watershed.from_streamstats_json` returns a fresh instance with isolated state, and `Watershed(...)` populates `self`.

## Test plan
- [x] One regression test in `tests/streamstats_test.py` covering the load-bearing behavior change: two watersheds built from different JSON must not share state via class-level attributes (`test_from_streamstats_json_does_not_mutate_class`). The other behaviors — `from_streamstats_json` returns an instance, `format="object"` returns a dict, `__init__` populates `self`, `_workspaceID` resolves — are each one-line obvious fixes; their tests were dropped as trivial.
- [x] Full local test suite passes.
- [ ] Reviewer: live-API verification was attempted but the StreamStats `watershed.geojson` endpoint is currently returning HTTP 404 for all tested coordinates (service-side issue independent of this PR). Suggested follow-up: re-run the existing `test_get_watershed` integration once StreamStats recovers.

## Follow-up
Filed a separate issue to discuss whether `get_watershed` should always return a `Watershed` (drop the `format` parameter). That would match the function name and the original narrative-docstring promise, but is a breaking change and out of scope for this bug-fix PR.