### PR TITLE
Fix nldi: validate data source on every call, not just cache-miss

### DIFF
--- a/dataretrieval/nldi.py
+++ b/dataretrieval/nldi.py
@@ -253,15 +253,11 @@ def get_features(
             raise ValueError(
                 "navigation_mode is required if comid or data_source is provided"
             )
-        # validate the feature source and comid
         _validate_feature_source_comid(feature_source, feature_id, comid)
-        # validate the data source
         if data_source is not None:
             _validate_data_source(data_source)
-        # validate feature source
         if feature_source is not None:
             _validate_data_source(feature_source)
-        # validate the navigation mode
         if navigation_mode:
             _validate_navigation_mode(navigation_mode)
 

--- a/dataretrieval/nldi.py
+++ b/dataretrieval/nldi.py
@@ -256,10 +256,10 @@ def get_features(
         # validate the feature source and comid
         _validate_feature_source_comid(feature_source, feature_id, comid)
         # validate the data source
-        if data_source:
+        if data_source is not None:
             _validate_data_source(data_source)
         # validate feature source
-        if feature_source:
+        if feature_source is not None:
             _validate_data_source(feature_source)
         # validate the navigation mode
         if navigation_mode:

--- a/dataretrieval/nldi.py
+++ b/dataretrieval/nldi.py
@@ -259,7 +259,8 @@ def get_features(
         if data_source:
             _validate_data_source(data_source)
         # validate feature source
-        _validate_data_source(feature_source)
+        if feature_source:
+            _validate_data_source(feature_source)
         # validate the navigation mode
         if navigation_mode:
             _validate_navigation_mode(navigation_mode)
@@ -475,12 +476,13 @@ def _validate_data_source(data_source: str):
             url, {}, "Error getting available data sources"
         )
         _AVAILABLE_DATA_SOURCES = [ds["source"] for ds in available_data_sources]
-        if data_source not in _AVAILABLE_DATA_SOURCES:
-            err_msg = (
-                f"Invalid data source '{data_source}'."
-                f" Available data sources are: {_AVAILABLE_DATA_SOURCES}"
-            )
-            raise ValueError(err_msg)
+
+    if data_source not in _AVAILABLE_DATA_SOURCES:
+        err_msg = (
+            f"Invalid data source '{data_source}'."
+            f" Available data sources are: {_AVAILABLE_DATA_SOURCES}"
+        )
+        raise ValueError(err_msg)
 
 
 def _validate_navigation_mode(navigation_mode: str):

--- a/tests/nldi_test.py
+++ b/tests/nldi_test.py
@@ -1,5 +1,7 @@
+import pytest
 from geopandas import GeoDataFrame
 
+import dataretrieval.nldi as nldi
 from dataretrieval.nldi import (
     NLDI_API_BASE_URL,
     get_basin,
@@ -7,6 +9,14 @@ from dataretrieval.nldi import (
     get_flowlines,
     search,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_data_source_cache():
+    """Reset the module-level cache between tests."""
+    nldi._AVAILABLE_DATA_SOURCES = None
+    yield
+    nldi._AVAILABLE_DATA_SOURCES = None
 
 
 def mock_request_data_sources(requests_mock):
@@ -280,3 +290,26 @@ def test_search_for_features_by_lat_long(requests_mock):
     assert search_results["features"][0]["type"] == "Feature"
     assert search_results["features"][0]["geometry"]["type"] == "LineString"
     assert len(search_results["features"][0]["geometry"]["coordinates"]) == 27
+
+
+def test_validate_data_source_rejects_invalid_after_cache_populated(requests_mock):
+    """Once the cache is warm, invalid data sources must still raise ValueError.
+
+    Regression: previously the validation check was nested inside the
+    cache-population branch, so all calls after the first silently passed.
+    """
+    mock_request_data_sources(requests_mock)
+
+    # First call: populates the cache with a valid source.
+    nldi._validate_data_source("WQP")
+
+    # Second call with an invalid source must raise.
+    with pytest.raises(ValueError, match="Invalid data source 'not_a_real_source'"):
+        nldi._validate_data_source("not_a_real_source")
+
+
+def test_validate_data_source_rejects_invalid_on_first_call(requests_mock):
+    """Cold-cache invalid sources must also raise."""
+    mock_request_data_sources(requests_mock)
+    with pytest.raises(ValueError, match="Invalid data source"):
+        nldi._validate_data_source("not_a_real_source")

--- a/tests/nldi_test.py
+++ b/tests/nldi_test.py
@@ -12,11 +12,9 @@ from dataretrieval.nldi import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_data_source_cache():
+def _reset_data_source_cache(monkeypatch):
     """Reset the module-level cache between tests."""
-    nldi._AVAILABLE_DATA_SOURCES = None
-    yield
-    nldi._AVAILABLE_DATA_SOURCES = None
+    monkeypatch.setattr(nldi, "_AVAILABLE_DATA_SOURCES", None)
 
 
 def mock_request_data_sources(requests_mock):
@@ -300,16 +298,7 @@ def test_validate_data_source_rejects_invalid_after_cache_populated(requests_moc
     """
     mock_request_data_sources(requests_mock)
 
-    # First call: populates the cache with a valid source.
     nldi._validate_data_source("WQP")
 
-    # Second call with an invalid source must raise.
     with pytest.raises(ValueError, match="Invalid data source 'not_a_real_source'"):
-        nldi._validate_data_source("not_a_real_source")
-
-
-def test_validate_data_source_rejects_invalid_on_first_call(requests_mock):
-    """Cold-cache invalid sources must also raise."""
-    mock_request_data_sources(requests_mock)
-    with pytest.raises(ValueError, match="Invalid data source"):
         nldi._validate_data_source("not_a_real_source")


### PR DESCRIPTION
## Summary
- `_validate_data_source` nested its `data_source not in cache` check inside the `if cache is None:` branch, so the validator was effectively a no-op after the first call. Any invalid `data_source` / `feature_source` value passed thereafter was silently accepted and used to construct an invalid URL, surfacing as a confusing 4xx from the server rather than a clean ValueError.
- Hoist the validation check outside the cache-load branch so every call validates.
- Also guards the unconditional `_validate_data_source(feature_source)` call in `get_features` with `if feature_source is not None:` — without this guard the now-active validator would raise "Invalid data source 'None'" whenever a user provided only `comid` (the cache bug previously masked this).

## Test plan
- [x] One regression test in `tests/nldi_test.py` that exercises the load-bearing behavior change: invalid sources must still raise after the cache is warm. Cold-cache test was dropped as redundant — the warm-cache test exercises the cold path on its first call.
- [x] An autouse `monkeypatch` fixture resets the module-level `_AVAILABLE_DATA_SOURCES` cache between tests to keep test order independent.
- [x] Full local test suite passes.

## Related PRs

- **#252** (`nldi-cleanup`) is a broader cleanup of `nldi.py` that adds the **same** `if feature_source:` guard at the same line in `get_features`. Trivial textual conflict at merge time; the fix is identical so either can land first.
- **#258** (`nldi-navigation-mode-valueerror`) touches a different function (`_validate_navigation_mode`) in the same file. No conflict.