### PR TITLE
Fix WQP_Metadata.site_info: bind as a real property and forward kwargs

### DIFF
--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -155,7 +155,7 @@ def get_results(
     response = query(url, kwargs, delimiter=";", ssl_check=ssl_check)
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_sites(
@@ -210,7 +210,7 @@ def what_sites(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_organizations(
@@ -265,7 +265,7 @@ def what_organizations(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_projects(ssl_check=True, legacy=True, **kwargs):
@@ -316,7 +316,7 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_activities(
@@ -380,7 +380,7 @@ def what_activities(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_detection_limits(
@@ -442,7 +442,7 @@ def what_detection_limits(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_habitat_metrics(
@@ -497,7 +497,7 @@ def what_habitat_metrics(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_project_weights(ssl_check=True, legacy=True, **kwargs):
@@ -553,7 +553,7 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
@@ -609,7 +609,7 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",")
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def wqp_url(service):
@@ -649,14 +649,15 @@ class WQP_Metadata(BaseMetadata):
     ----------
     url : str
         Response url
-    query_time : datetme.timedelta
+    query_time : datetime.timedelta
         Response elapsed time
     header : requests.structures.CaseInsensitiveDict
         Response headers
-    comments : None
-        Metadata comments. WQP does not return comments.
-    site_info : tuple[pd.DataFrame, NWIS_Metadata] | None
-        Site information if the query included `sites`, `site` or `site_no`.
+    comment : None
+        Metadata comment. WQP does not return comments.
+    site_info : tuple[pd.DataFrame, WQP_Metadata] | None
+        Site information if the query included a site filter (`siteid`,
+        `sites`, `site`, or `site_no`).
     """
 
     def __init__(self, response, **parameters) -> None:
@@ -682,14 +683,14 @@ class WQP_Metadata(BaseMetadata):
 
         self._parameters = parameters
 
-        @property
-        def site_info(self):
-            if "sites" in self._parameters:
-                return what_sites(sites=parameters["sites"])
-            elif "site" in self._parameters:
-                return what_sites(sites=parameters["site"])
-            elif "site_no" in self._parameters:
-                return what_sites(sites=parameters["site_no"])
+    @property
+    def site_info(self):
+        if "siteid" in self._parameters:
+            return what_sites(siteid=self._parameters["siteid"])
+        for legacy_key in ("sites", "site", "site_no"):
+            if legacy_key in self._parameters:
+                return what_sites(siteid=self._parameters[legacy_key])
+        return None
 
 
 def _check_kwargs(kwargs):

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -12,6 +12,7 @@ See https://waterqualitydata.us/webservices_documentation for API reference
 from __future__ import annotations
 
 import warnings
+from functools import cached_property
 from io import StringIO
 from typing import TYPE_CHECKING
 
@@ -687,8 +688,10 @@ class WQP_Metadata(BaseMetadata):
         self._legacy = legacy
         self._ssl_check = ssl_check
 
-    @property
+    @cached_property
     def site_info(self):
+        # Walk WQP-native key first, then legacy NWIS-style aliases. Whichever
+        # matched, pass the value as `siteid` -- that's what_sites' native arg.
         for key in ("siteid", "sites", "site", "site_no"):
             if key in self._parameters:
                 return what_sites(

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -685,11 +685,9 @@ class WQP_Metadata(BaseMetadata):
 
     @property
     def site_info(self):
-        if "siteid" in self._parameters:
-            return what_sites(siteid=self._parameters["siteid"])
-        for legacy_key in ("sites", "site", "site_no"):
-            if legacy_key in self._parameters:
-                return what_sites(siteid=self._parameters[legacy_key])
+        for key in ("siteid", "sites", "site", "site_no"):
+            if key in self._parameters:
+                return what_sites(siteid=self._parameters[key])
         return None
 
 

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -12,6 +12,7 @@ See https://waterqualitydata.us/webservices_documentation for API reference
 from __future__ import annotations
 
 import warnings
+from functools import cached_property
 from io import StringIO
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,10 @@ from .utils import BaseMetadata, query
 
 if TYPE_CHECKING:
     from pandas import DataFrame
+
+# WQP-native site key first, then legacy NWIS-style aliases. WQP_Metadata.site_info
+# walks these in order and forwards whichever matched as what_sites' `siteid`.
+_SITE_KEYS = ("siteid", "sites", "site", "site_no")
 
 
 result_profiles_wqx3 = ["basicPhysChem", "fullPhysChem", "narrow"]
@@ -661,11 +666,9 @@ class WQP_Metadata(BaseMetadata):
         self._legacy = legacy
         self._ssl_check = ssl_check
 
-    @property
+    @cached_property
     def site_info(self):
-        # Walk WQP-native key first, then legacy NWIS-style aliases. Whichever
-        # matched, pass the value as `siteid` -- that's what_sites' native arg.
-        for key in ("siteid", "sites", "site", "site_no"):
+        for key in _SITE_KEYS:
             if key in self._parameters:
                 return what_sites(
                     siteid=self._parameters[key],

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -155,7 +155,7 @@ def get_results(
     response = query(url, kwargs, delimiter=";", ssl_check=ssl_check)
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_sites(
@@ -210,7 +210,7 @@ def what_sites(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_organizations(
@@ -265,7 +265,7 @@ def what_organizations(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_projects(ssl_check=True, legacy=True, **kwargs):
@@ -316,7 +316,7 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_activities(
@@ -380,7 +380,7 @@ def what_activities(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_detection_limits(
@@ -442,7 +442,7 @@ def what_detection_limits(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_habitat_metrics(
@@ -497,7 +497,7 @@ def what_habitat_metrics(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_project_weights(ssl_check=True, legacy=True, **kwargs):
@@ -553,7 +553,7 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
@@ -609,7 +609,7 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",")
 
-    return df, WQP_Metadata(response, **kwargs)
+    return df, WQP_Metadata(response, legacy=legacy, ssl_check=ssl_check, **kwargs)
 
 
 def wqp_url(service):
@@ -660,7 +660,9 @@ class WQP_Metadata(BaseMetadata):
         `sites`, `site`, or `site_no`).
     """
 
-    def __init__(self, response, **parameters) -> None:
+    def __init__(
+        self, response, legacy: bool = True, ssl_check: bool = True, **parameters
+    ) -> None:
         """Generates a standard set of metadata informed by the response with specific
         metadata for WQP data.
 
@@ -668,9 +670,17 @@ class WQP_Metadata(BaseMetadata):
         ----------
         response : Response
             Response object from requests module
-
+        legacy : bool
+            Whether the originating request used the legacy WQX endpoint.
+            Forwarded to ``what_sites`` when ``site_info`` is accessed so the
+            resolved station metadata uses the same profile as the original
+            query.
+        ssl_check : bool
+            Whether the originating request verified SSL. Forwarded to
+            ``what_sites`` for consistency.
         parameters : dict
-            Unpacked dictionary of the parameters supplied in the request
+            Unpacked dictionary of the remaining parameters supplied in the
+            request.
 
         Returns
         -------
@@ -682,12 +692,18 @@ class WQP_Metadata(BaseMetadata):
         super().__init__(response)
 
         self._parameters = parameters
+        self._legacy = legacy
+        self._ssl_check = ssl_check
 
     @property
     def site_info(self):
         for key in ("siteid", "sites", "site", "site_no"):
             if key in self._parameters:
-                return what_sites(siteid=self._parameters[key])
+                return what_sites(
+                    siteid=self._parameters[key],
+                    legacy=self._legacy,
+                    ssl_check=self._ssl_check,
+                )
         return None
 
 

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -12,7 +12,6 @@ See https://waterqualitydata.us/webservices_documentation for API reference
 from __future__ import annotations
 
 import warnings
-from functools import cached_property
 from io import StringIO
 from typing import TYPE_CHECKING
 
@@ -688,7 +687,7 @@ class WQP_Metadata(BaseMetadata):
         self._legacy = legacy
         self._ssl_check = ssl_check
 
-    @cached_property
+    @property
     def site_info(self):
         # Walk WQP-native key first, then legacy NWIS-style aliases. Whichever
         # matched, pass the value as `siteid` -- that's what_sites' native arg.

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -1,9 +1,11 @@
 import datetime
+from unittest import mock
 
 import pytest
 from pandas import DataFrame
 
 from dataretrieval.wqp import (
+    WQP_Metadata,
     _check_kwargs,
     get_results,
     what_activities,
@@ -219,13 +221,7 @@ def test_check_kwargs():
 
 
 def test_wqp_metadata_site_info_property_resolves(requests_mock):
-    """`site_info` must be a real property bound to the class.
-
-    Regression: previously `site_info` was defined as a closure inside
-    `__init__`, so `md.site_info` fell through to `BaseMetadata.site_info`
-    and raised `NotImplementedError`. Also verify the parameters are
-    threaded through from `get_results`.
-    """
+    """`site_info` returns the `(DataFrame, WQP_Metadata)` tuple from `what_sites`."""
     results_url = (
         "https://www.waterqualitydata.us/data/Result/Search?"
         "siteid=WIDNR_WQX-10032762&mimeType=csv"
@@ -239,8 +235,6 @@ def test_wqp_metadata_site_info_property_resolves(requests_mock):
 
     _df, md = get_results(siteid="WIDNR_WQX-10032762")
 
-    # site_info must be a bound property — accessing it should return the
-    # what_sites() tuple, not raise NotImplementedError.
     site_df, site_md = md.site_info
     assert isinstance(site_df, DataFrame)
     assert site_md.url == sites_url
@@ -260,11 +254,7 @@ def test_wqp_metadata_site_info_returns_none_without_site_filter(requests_mock):
 def test_wqp_metadata_site_info_uses_wqx3_when_originating_query_was_wqx3(
     requests_mock,
 ):
-    """`site_info` must use the same legacy/WQX3.0 profile as the originating query.
-
-    Regression: previously `site_info` always called `what_sites()` with default
-    `legacy=True`, so a WQX3.0 results query produced a legacy Station lookup.
-    """
+    """`site_info` reuses the originating legacy/WQX3.0 profile."""
     results_url = (
         "https://www.waterqualitydata.us/wqx3/Result/search?"
         "siteid=UTAHDWQ_WQX-4993795&mimeType=csv&dataProfile=fullPhysChem"
@@ -279,6 +269,18 @@ def test_wqp_metadata_site_info_uses_wqx3_when_originating_query_was_wqx3(
     _df, md = get_results(legacy=False, siteid="UTAHDWQ_WQX-4993795")
     _site_df, site_md = md.site_info
     assert site_md.url == sites_wqx3_url
+
+
+@pytest.mark.parametrize("key", ["siteid", "sites", "site", "site_no"])
+def test_wqp_metadata_site_info_forwards_each_alias_as_siteid(key):
+    """Every alias key resolves to `what_sites(siteid=value, ...)`."""
+    with mock.patch("dataretrieval.wqp.what_sites") as fake_what_sites:
+        fake_what_sites.return_value = (DataFrame(), mock.Mock())
+        md = WQP_Metadata(mock.Mock(), legacy=False, ssl_check=True, **{key: "USGS-X"})
+        _ = md.site_info
+        fake_what_sites.assert_called_once_with(
+            siteid="USGS-X", legacy=False, ssl_check=True
+        )
 
 
 def test_get_results_wqx3_preserves_user_dataProfile(requests_mock):

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -216,3 +216,42 @@ def test_check_kwargs():
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
+
+
+def test_wqp_metadata_site_info_property_resolves(requests_mock):
+    """`site_info` must be a real property bound to the class.
+
+    Regression: previously `site_info` was defined as a closure inside
+    `__init__`, so `md.site_info` fell through to `BaseMetadata.site_info`
+    and raised `NotImplementedError`. Also verify the parameters are
+    threaded through from `get_results`.
+    """
+    results_url = (
+        "https://www.waterqualitydata.us/data/Result/Search?"
+        "siteid=WIDNR_WQX-10032762&mimeType=csv"
+    )
+    sites_url = (
+        "https://www.waterqualitydata.us/data/Station/Search?"
+        "siteid=WIDNR_WQX-10032762&mimeType=csv"
+    )
+    mock_request(requests_mock, results_url, "tests/data/wqp_results.txt")
+    mock_request(requests_mock, sites_url, "tests/data/wqp_sites.txt")
+
+    _df, md = get_results(siteid="WIDNR_WQX-10032762")
+
+    # site_info must be a bound property — accessing it should return the
+    # what_sites() tuple, not raise NotImplementedError.
+    site_df, site_md = md.site_info
+    assert isinstance(site_df, DataFrame)
+    assert site_md.url == sites_url
+
+
+def test_wqp_metadata_site_info_returns_none_without_site_filter(requests_mock):
+    """`site_info` returns None when no site filter was supplied."""
+    results_url = (
+        "https://www.waterqualitydata.us/data/Result/Search?"
+        "characteristicName=Chloride&mimeType=csv"
+    )
+    mock_request(requests_mock, results_url, "tests/data/wqp_results.txt")
+    _df, md = get_results(characteristicName="Chloride")
+    assert md.site_info is None

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -255,3 +255,27 @@ def test_wqp_metadata_site_info_returns_none_without_site_filter(requests_mock):
     mock_request(requests_mock, results_url, "tests/data/wqp_results.txt")
     _df, md = get_results(characteristicName="Chloride")
     assert md.site_info is None
+
+
+def test_wqp_metadata_site_info_uses_wqx3_when_originating_query_was_wqx3(
+    requests_mock,
+):
+    """`site_info` must use the same legacy/WQX3.0 profile as the originating query.
+
+    Regression: previously `site_info` always called `what_sites()` with default
+    `legacy=True`, so a WQX3.0 results query produced a legacy Station lookup.
+    """
+    results_url = (
+        "https://www.waterqualitydata.us/wqx3/Result/search?"
+        "siteid=UTAHDWQ_WQX-4993795&mimeType=csv&dataProfile=fullPhysChem"
+    )
+    sites_wqx3_url = (
+        "https://www.waterqualitydata.us/wqx3/Station/search?"
+        "siteid=UTAHDWQ_WQX-4993795&mimeType=csv"
+    )
+    mock_request(requests_mock, results_url, "tests/data/wqp3_results.txt")
+    mock_request(requests_mock, sites_wqx3_url, "tests/data/wqp_sites.txt")
+
+    _df, md = get_results(legacy=False, siteid="UTAHDWQ_WQX-4993795")
+    _site_df, site_md = md.site_info
+    assert site_md.url == sites_wqx3_url


### PR DESCRIPTION
## Summary
`WQP_Metadata.site_info` was defined inside `__init__` as a nested `@property`-decorated function that was never bound to the class. The decorator returned a property descriptor that was immediately discarded when `__init__` returned, so `md.site_info` always fell through to `BaseMetadata.site_info` and raised `NotImplementedError`. The closure also used `parameters[...]` (the captured `**parameters` kwargs) for the lookup but `self._parameters` for the `in` check — an internal inconsistency.

Compounding the issue, every helper called `WQP_Metadata(response)` with no kwargs, so `self._parameters` was always `{}` even after fixing the closure.

This PR:
- Moves `site_info` to a real `@property` on the class.
- Looks up `siteid` first (WQP-native; the previous `sites` / `site` / `site_no` keys reflected an NWIS copy-paste and never matched a WQP query) while keeping the legacy aliases as a fallback.
- Threads `**kwargs` through `WQP_Metadata(response, **kwargs)` from all nine call sites so the property has the parameters it needs.
- Corrects the docstring: the attribute is `comment` (singular, inherited from `BaseMetadata`) and `query_time` is a `datetime.timedelta` (was `datetme.timedelta`).

## Minimal reproducible example

### Pre-fix bug

```python
import dataretrieval.wqp as wqp

df, md = wqp.what_sites(legacy=True, siteid="USGS-01646500")
md.site_info
# NotImplementedError: BaseMetadata does not implement site_info
```

The pre-fix shape that causes this:

```python
class WQP_Metadata(BaseMetadata):
    def __init__(self, response, **parameters):
        self._response = response
        self._parameters = parameters
        @property                 # decorator runs here
        def site_info(self):      # but the result is a local variable —
            ...                   # it's never attached to the class.
```

So `md.site_info` always resolves to `BaseMetadata.site_info`, which raises.

### Post-fix, live API

```python
import dataretrieval.wqp as wqp

df, md = wqp.what_sites(legacy=True, siteid="USGS-01646500")
print(len(df))                      # 1
result = md.site_info
print(type(result).__name__)        # tuple
df2, md2 = result
print(len(df2))                     # 1
```

## Test plan
- [x] New regression tests in `tests/wqp_test.py`: `site_info` resolves and returns a `(DataFrame, WQP_Metadata)` tuple when `siteid` was provided; returns `None` when no site filter was supplied.
- [x] All `tests/wqp_test.py` (15 tests) pass.
- [x] Full local test suite passes.
- [x] Live verification against the WQP: `md.site_info` now returns the expected tuple.

## Related PRs

Other open PRs in this bug-review series that touch `dataretrieval/wqp.py` (different functions, no functional conflicts):
- **#250** — preserve user-supplied WQX3.0 `dataProfile` in `get_results`.
- **#256** — polish (warnings instead of print, exception shape, typos, helper extraction).