### PR TITLE
Fix get_results: preserve user-supplied WQX3.0 dataProfile

### DIFF
--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -126,7 +126,7 @@ def get_results(
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy:
+    if legacy is True:
         valid_profiles = result_profiles_legacy
         kind = "legacy"
         url = wqp_url("Result")
@@ -141,7 +141,7 @@ def get_results(
             f"dataProfile {profile!r} is not a valid {kind} profile. "
             f"Valid options are {valid_profiles}."
         )
-    if not legacy and profile is None:
+    if legacy is not True and profile is None:
         kwargs["dataProfile"] = "fullPhysChem"
 
     response = query(url, kwargs, delimiter=";", ssl_check=ssl_check)

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -126,29 +126,23 @@ def get_results(
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        if (
-            "dataProfile" in kwargs
-            and kwargs["dataProfile"] not in result_profiles_legacy
-        ):
-            raise ValueError(
-                f"dataProfile {kwargs['dataProfile']!r} is not a legacy profile. "
-                f"Valid options are {result_profiles_legacy}."
-            )
-
+    if legacy:
+        valid_profiles = result_profiles_legacy
+        kind = "legacy"
         url = wqp_url("Result")
-
     else:
-        if "dataProfile" in kwargs:
-            if kwargs["dataProfile"] not in result_profiles_wqx3:
-                raise ValueError(
-                    f"dataProfile {kwargs['dataProfile']!r} is not a valid "
-                    f"WQX3.0 profile. Valid options are {result_profiles_wqx3}."
-                )
-        else:
-            kwargs["dataProfile"] = "fullPhysChem"
-
+        valid_profiles = result_profiles_wqx3
+        kind = "WQX3.0"
         url = wqx3_url("Result")
+
+    profile = kwargs.get("dataProfile")
+    if profile is not None and profile not in valid_profiles:
+        raise ValueError(
+            f"dataProfile {profile!r} is not a valid {kind} profile. "
+            f"Valid options are {valid_profiles}."
+        )
+    if not legacy and profile is None:
+        kwargs["dataProfile"] = "fullPhysChem"
 
     response = query(url, kwargs, delimiter=";", ssl_check=ssl_check)
 

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -131,22 +131,20 @@ def get_results(
             "dataProfile" in kwargs
             and kwargs["dataProfile"] not in result_profiles_legacy
         ):
-            raise TypeError(
-                f"dataProfile {kwargs['dataProfile']} is not a legacy profile.",
-                f"Valid options are {result_profiles_legacy}.",
+            raise ValueError(
+                f"dataProfile {kwargs['dataProfile']!r} is not a legacy profile. "
+                f"Valid options are {result_profiles_legacy}."
             )
 
         url = wqp_url("Result")
 
     else:
-        if (
-            "dataProfile" in kwargs
-            and kwargs["dataProfile"] not in result_profiles_wqx3
-        ):
-            raise TypeError(
-                f"dataProfile {kwargs['dataProfile']} is not a valid WQX3.0"
-                f"profile. Valid options are {result_profiles_wqx3}.",
-            )
+        if "dataProfile" in kwargs:
+            if kwargs["dataProfile"] not in result_profiles_wqx3:
+                raise ValueError(
+                    f"dataProfile {kwargs['dataProfile']!r} is not a valid "
+                    f"WQX3.0 profile. Valid options are {result_profiles_wqx3}."
+                )
         else:
             kwargs["dataProfile"] = "fullPhysChem"
 

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -238,15 +238,3 @@ def test_get_results_wqx3_preserves_user_dataProfile(requests_mock):
     assert isinstance(df, DataFrame)
     sent = requests_mock.request_history[-1]
     assert sent.qs.get("dataprofile") == ["narrow"]
-
-
-def test_get_results_wqx3_invalid_dataProfile_raises():
-    """Invalid WQX3.0 dataProfile raises ValueError, not TypeError."""
-    with pytest.raises(ValueError, match="WQX3.0 profile"):
-        get_results(legacy=False, dataProfile="not_a_real_profile")
-
-
-def test_get_results_legacy_invalid_dataProfile_raises():
-    """Invalid legacy dataProfile raises ValueError, not TypeError."""
-    with pytest.raises(ValueError, match="legacy profile"):
-        get_results(legacy=True, dataProfile="not_a_real_profile")

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -216,3 +216,37 @@ def test_check_kwargs():
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
+
+
+def test_get_results_wqx3_preserves_user_dataProfile(requests_mock):
+    """A valid user-supplied WQX3.0 profile must not be overwritten.
+
+    Regression: previously the `else` branch of the `dataProfile` validation
+    triggered whenever the value was *not invalid*, including any valid
+    user-supplied profile, silently overwriting it with 'fullPhysChem'.
+    """
+    request_url = (
+        "https://www.waterqualitydata.us/wqx3/Result/search?"
+        "siteid=UTAHDWQ_WQX-4993795&mimeType=csv&dataProfile=narrow"
+    )
+    response_file_path = "tests/data/wqp3_results.txt"
+    mock_request(requests_mock, request_url, response_file_path)
+
+    df, _md = get_results(
+        legacy=False, siteid="UTAHDWQ_WQX-4993795", dataProfile="narrow"
+    )
+    assert isinstance(df, DataFrame)
+    sent = requests_mock.request_history[-1]
+    assert sent.qs.get("dataprofile") == ["narrow"]
+
+
+def test_get_results_wqx3_invalid_dataProfile_raises():
+    """Invalid WQX3.0 dataProfile raises ValueError, not TypeError."""
+    with pytest.raises(ValueError, match="WQX3.0 profile"):
+        get_results(legacy=False, dataProfile="not_a_real_profile")
+
+
+def test_get_results_legacy_invalid_dataProfile_raises():
+    """Invalid legacy dataProfile raises ValueError, not TypeError."""
+    with pytest.raises(ValueError, match="legacy profile"):
+        get_results(legacy=True, dataProfile="not_a_real_profile")


### PR DESCRIPTION
## Summary
The validation block silently overwrote any user-supplied WQX3.0 `dataProfile` because the `else` clause attached to the *outer* `if "dataProfile" in kwargs and ... not in result_profiles_wqx3` and fired whenever that compound condition was False — including the case where the user passed a *valid* profile like `"narrow"` or `"basicPhysChem"`. The documented example `dataProfile="narrow"` therefore did not actually request the narrow profile.

This PR restructures the WQX3.0 branch so the default (`fullPhysChem`) is only applied when the user did *not* set `dataProfile` at all.

It also raises `ValueError` rather than `TypeError` for invalid profile values (these are bad *values*, not bad types) and calls the constructor with a single formatted message — the previous code passed two separate strings, producing a tuple-args exception that printed as `('msg1', 'msg2')`.

## Test plan
- [x] One new regression test in `tests/wqp_test.py` — `test_get_results_wqx3_preserves_user_dataProfile` — confirms a valid user-supplied WQX3.0 profile (`"narrow"`) is preserved end-to-end through the request URL. The accompanying `TypeError` -> `ValueError` shape fix is documented by the diff and not separately unit-tested.
- [x] All `tests/wqp_test.py` (12 tests) pass.
- [x] Full local test suite passes (with `API_USGS_PAT` set).

## Related PRs

Other open PRs in this bug-review series that touch `dataretrieval/wqp.py` (different functions, no functional conflicts):
- **#249** — fix `WQP_Metadata.site_info` property binding.
- **#256** — polish (warnings instead of print, exception shape, typos, helper extraction). Earlier draft of #256 also touched `get_results`'s `TypeError` -> `ValueError` shape; that overlap was reverted so this PR fully owns the `get_results` rewrite.