### PR TITLE
Fix get_nearest_continuous: accept scalar targets and missing time column

### DIFF
--- a/dataretrieval/waterdata/nearest.py
+++ b/dataretrieval/waterdata/nearest.py
@@ -139,7 +139,7 @@ def get_nearest_continuous(
         ... )
     """
     _check_nearest_kwargs(kwargs, on_tie)
-    target_index = pd.DatetimeIndex(pd.to_datetime(targets, utc=True))
+    target_index = _coerce_targets(targets)
     window_td = pd.Timedelta(window)
 
     if len(target_index) == 0:
@@ -153,6 +153,11 @@ def get_nearest_continuous(
         filter_lang="cql-text",
         **kwargs,
     )
+    if "time" not in df.columns:
+        raise ValueError(
+            "get_nearest_continuous requires a 'time' column in the response; "
+            "if a `properties` kwarg was passed, include 'time' in it"
+        )
     if df.empty:
         return _empty_nearest_result(df), md
 
@@ -172,6 +177,19 @@ def get_nearest_continuous(
     if not selected:
         return _empty_nearest_result(df), md
     return pd.DataFrame(selected).reset_index(drop=True), md
+
+
+def _coerce_targets(targets: Any) -> pd.DatetimeIndex:
+    """Accept anything ``pandas.to_datetime`` consumes, including a single value.
+
+    A bare scalar (string, ``Timestamp``, ``datetime``, …) becomes a
+    one-element ``DatetimeIndex``; an iterable round-trips through
+    ``pd.to_datetime`` directly.
+    """
+    parsed = pd.to_datetime(targets, utc=True)
+    if isinstance(parsed, pd.DatetimeIndex):
+        return parsed
+    return pd.DatetimeIndex([parsed])
 
 
 def _check_nearest_kwargs(kwargs: dict[str, Any], on_tie: OnTie) -> None:

--- a/dataretrieval/waterdata/nearest.py
+++ b/dataretrieval/waterdata/nearest.py
@@ -183,13 +183,15 @@ def _coerce_targets(targets: Any) -> pd.DatetimeIndex:
     """Accept anything ``pandas.to_datetime`` consumes, including a single value.
 
     A bare scalar (string, ``Timestamp``, ``datetime``, …) becomes a
-    one-element ``DatetimeIndex``; an iterable round-trips through
-    ``pd.to_datetime`` directly.
+    one-element ``DatetimeIndex``; an iterable (list, ``Series``, ``ndarray``)
+    is wrapped directly so its elements are preserved.
     """
     parsed = pd.to_datetime(targets, utc=True)
     if isinstance(parsed, pd.DatetimeIndex):
         return parsed
-    return pd.DatetimeIndex([parsed])
+    if pd.api.types.is_scalar(parsed):
+        return pd.DatetimeIndex([parsed])
+    return pd.DatetimeIndex(parsed)
 
 
 def _check_nearest_kwargs(kwargs: dict[str, Any], on_tie: OnTie) -> None:

--- a/dataretrieval/waterdata/nearest.py
+++ b/dataretrieval/waterdata/nearest.py
@@ -187,10 +187,8 @@ def _coerce_targets(targets: Any) -> pd.DatetimeIndex:
     is wrapped directly so its elements are preserved.
     """
     parsed = pd.to_datetime(targets, utc=True)
-    if isinstance(parsed, pd.DatetimeIndex):
-        return parsed
     if pd.api.types.is_scalar(parsed):
-        return pd.DatetimeIndex([parsed])
+        parsed = [parsed]
     return pd.DatetimeIndex(parsed)
 
 

--- a/tests/waterdata_nearest_test.py
+++ b/tests/waterdata_nearest_test.py
@@ -265,3 +265,54 @@ def test_forwards_kwargs_to_get_continuous(patch_get_continuous):
     _, kwargs = patch_get_continuous.call_args
     assert kwargs["statistic_id"] == "00011"
     assert kwargs["approval_status"] == "Approved"
+
+
+def test_accepts_single_string_target(patch_get_continuous):
+    """A bare scalar target must round-trip through pd.to_datetime.
+
+    Regression: previously `pd.DatetimeIndex(pd.to_datetime("...", utc=True))`
+    raised TypeError because pd.to_datetime returns a scalar Timestamp for a
+    single-string input.
+    """
+    patch_get_continuous.return_value = (
+        _fake_df([{"time": "2023-06-15T10:30:00Z", "value": 22.4}]),
+        mock.Mock(),
+    )
+    result, _ = get_nearest_continuous(
+        "2023-06-15T10:30:31Z", monitoring_location_id="USGS-02238500"
+    )
+    assert len(result) == 1
+    assert result["target_time"].iloc[0] == pd.Timestamp(
+        "2023-06-15T10:30:31Z", tz="UTC"
+    )
+
+
+def test_accepts_single_timestamp_target(patch_get_continuous):
+    """A single ``pd.Timestamp`` target also round-trips."""
+    patch_get_continuous.return_value = (
+        _fake_df([{"time": "2023-06-15T10:30:00Z", "value": 22.4}]),
+        mock.Mock(),
+    )
+    target = pd.Timestamp("2023-06-15T10:30:31Z", tz="UTC")
+    result, _ = get_nearest_continuous(target, monitoring_location_id="USGS-02238500")
+    assert len(result) == 1
+
+
+def test_missing_time_column_raises_helpful_error(patch_get_continuous):
+    """If the response has no 'time' column (e.g. user passed `properties`
+    that excluded it), raise ValueError instead of crashing with KeyError.
+    """
+    df_no_time = pd.DataFrame(
+        {
+            "value": [22.4],
+            "monitoring_location_id": ["USGS-02238500"],
+        }
+    )
+    patch_get_continuous.return_value = (df_no_time, mock.Mock())
+
+    with pytest.raises(ValueError, match="'time' column"):
+        get_nearest_continuous(
+            ["2023-06-15T10:30:31Z"],
+            monitoring_location_id="USGS-02238500",
+            properties=["value", "monitoring_location_id"],
+        )

--- a/tests/waterdata_nearest_test.py
+++ b/tests/waterdata_nearest_test.py
@@ -282,9 +282,7 @@ def test_accepts_single_string_target(patch_get_continuous):
         "2023-06-15T10:30:31Z", monitoring_location_id="USGS-02238500"
     )
     assert len(result) == 1
-    assert result["target_time"].iloc[0] == pd.Timestamp(
-        "2023-06-15T10:30:31Z", tz="UTC"
-    )
+    assert result["target_time"].iloc[0] == pd.Timestamp("2023-06-15T10:30:31Z")
 
 
 def test_accepts_single_timestamp_target(patch_get_continuous):
@@ -293,9 +291,25 @@ def test_accepts_single_timestamp_target(patch_get_continuous):
         _fake_df([{"time": "2023-06-15T10:30:00Z", "value": 22.4}]),
         mock.Mock(),
     )
-    target = pd.Timestamp("2023-06-15T10:30:31Z", tz="UTC")
+    target = pd.Timestamp("2023-06-15T10:30:31Z")
     result, _ = get_nearest_continuous(target, monitoring_location_id="USGS-02238500")
     assert len(result) == 1
+
+
+def test_accepts_pandas_series_targets(patch_get_continuous):
+    """A ``pd.Series`` of timestamps preserves all elements (not just the first)."""
+    patch_get_continuous.return_value = (
+        _fake_df(
+            [
+                {"time": "2023-06-15T10:30:00Z", "value": 22.4},
+                {"time": "2023-06-16T10:30:00Z", "value": 22.5},
+            ]
+        ),
+        mock.Mock(),
+    )
+    targets = pd.Series(["2023-06-15T10:30:31Z", "2023-06-16T10:30:31Z"])
+    result, _ = get_nearest_continuous(targets, monitoring_location_id="USGS-02238500")
+    assert len(result) == 2
 
 
 def test_missing_time_column_raises_helpful_error(patch_get_continuous):


### PR DESCRIPTION
## Summary
The docstring says `targets` accepts "anything `pandas.to_datetime` consumes", which includes a bare string or `pd.Timestamp`. But `pd.to_datetime("2024-01-01T00:00:00Z", utc=True)` returns a scalar `Timestamp`, and `pd.DatetimeIndex(scalar)` raises `TypeError` — so single-value cases crashed despite the documented contract.

This PR:
- Adds a small `_coerce_targets` helper that wraps a scalar result in a one-element `DatetimeIndex` so any `pandas.to_datetime`-consumable input works.
- Detects when the response is missing a `time` column (e.g. the user passed `properties` that excluded it) up front and raises `ValueError` with a pointer at the likely cause, instead of crashing with `KeyError` deep inside `df.assign`.

## Minimal reproducible example

### Pre-fix bug (scalar target):

```python
import pandas as pd

# This is the relevant pre-fix construct from get_nearest_continuous:
pd.DatetimeIndex(pd.to_datetime("2024-01-01T00:00:00Z", utc=True))
# TypeError: DatetimeIndex(...) must be called with a collection of some kind,
#            Timestamp('2024-01-01 00:00:00+0000', tz='UTC') was passed

pd.DatetimeIndex(pd.to_datetime(pd.Timestamp("2024-01-01"), utc=True))
# Same TypeError.

# Only a list/tuple worked:
pd.DatetimeIndex(pd.to_datetime(["2024-01-01"], utc=True))  # OK
```

### Post-fix, live API:

```python
from dataretrieval.waterdata import get_nearest_continuous

df, md = get_nearest_continuous(
    monitoring_location_id="USGS-01646500",
    parameter_code="00060",
    targets="2024-01-01T12:00:00Z",   # bare string — formerly crashed
)
print(df[["time", "value"]])
#                        time  value
# 0 2024-01-01 12:00:00+00:00   9260
```

## Test plan
- [x] Three new regression tests in `tests/waterdata_nearest_test.py`: single string target round-trips; single `pd.Timestamp` target round-trips; response missing the `time` column raises a helpful `ValueError`.
- [x] Full `tests/waterdata_nearest_test.py` suite (23 tests) passes.
- [x] Live verification against the USGS waterdata API: scalar `targets="2024-01-01T12:00:00Z"` returns the expected single-row DataFrame.