### PR TITLE
Fix _arrange_cols: stop mutating the caller's properties list

### DIFF
--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -684,8 +684,8 @@ def _arrange_cols(
     # Rename id column to output_id
     df = df.rename(columns={"id": output_id})
 
-    # If properties are provided, filter to only those columns
-    # plus geometry if skip_geometry is False
+    # If properties are provided, filter to only those columns,
+    # appending the geometry column when present in the DataFrame.
     if properties and not all(pd.isna(properties)):
         # Don't alias the caller's list — we mutate below.
         local_properties = list(properties)

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -687,15 +687,17 @@ def _arrange_cols(
     # If properties are provided, filter to only those columns
     # plus geometry if skip_geometry is False
     if properties and not all(pd.isna(properties)):
+        # Work on a local copy so we don't mutate the caller's list across calls.
+        local_properties = list(properties)
         # Make sure geometry stays in the dataframe if skip_geometry is False
-        if "geometry" in df.columns and "geometry" not in properties:
-            properties.append("geometry")
+        if "geometry" in df.columns and "geometry" not in local_properties:
+            local_properties.append("geometry")
         # id is technically a valid column from the service, but these
         # functions make the name more specific. So, if someone requests
         # 'id', give them the output_id column
-        if "id" in properties:
-            properties[properties.index("id")] = output_id
-        df = df.loc[:, [col for col in properties if col in df.columns]]
+        if "id" in local_properties:
+            local_properties[local_properties.index("id")] = output_id
+        df = df.loc[:, [col for col in local_properties if col in df.columns]]
 
     # Move meaningless-to-user, extra id columns to the end
     # of the dataframe, if they exist

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -687,14 +687,12 @@ def _arrange_cols(
     # If properties are provided, filter to only those columns
     # plus geometry if skip_geometry is False
     if properties and not all(pd.isna(properties)):
-        # Work on a local copy so we don't mutate the caller's list across calls.
+        # Don't alias the caller's list — we mutate below.
         local_properties = list(properties)
-        # Make sure geometry stays in the dataframe if skip_geometry is False
         if "geometry" in df.columns and "geometry" not in local_properties:
             local_properties.append("geometry")
-        # id is technically a valid column from the service, but these
-        # functions make the name more specific. So, if someone requests
-        # 'id', give them the output_id column
+        # 'id' is a valid service column, but expose it under the
+        # service-specific output_id name instead.
         if "id" in local_properties:
             local_properties[local_properties.index("id")] = output_id
         df = df.loc[:, [col for col in local_properties if col in df.columns]]

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -684,8 +684,6 @@ def _arrange_cols(
     # Rename id column to output_id
     df = df.rename(columns={"id": output_id})
 
-    # If properties are provided, filter to only those columns,
-    # appending the geometry column when present in the DataFrame.
     if properties and not all(pd.isna(properties)):
         # Don't alias the caller's list — we mutate below.
         local_properties = list(properties)

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
+import pandas as pd
 import requests
 
 from dataretrieval.waterdata.utils import (
+    _arrange_cols,
     _get_args,
     _walk_pages,
 )
@@ -80,3 +82,47 @@ def test_walk_pages_multiple_mocked():
     assert mock_client.send.called
     assert mock_client.request.called
     assert mock_client.request.call_args[0][1] == "https://example.com/page2"
+
+
+# --- _arrange_cols ----------------------------------------------------------
+
+
+def test_arrange_cols_does_not_mutate_caller_properties():
+    """`_arrange_cols` must not mutate the caller's `properties` list.
+
+    Regression: previously the function did
+    ``properties.append("geometry")`` and
+    ``properties[properties.index("id")] = output_id`` in place, so the
+    caller's list grew and was rewritten across successive calls.
+    """
+    df = pd.DataFrame(
+        {
+            "id": ["a", "b"],
+            "value": [1.0, 2.0],
+            "geometry": ["p1", "p2"],
+        }
+    )
+    properties = ["id", "value"]
+    snapshot = list(properties)
+
+    _arrange_cols(df, properties, output_id="daily_id")
+    _arrange_cols(df, properties, output_id="daily_id")
+
+    assert properties == snapshot, (
+        f"caller's properties list was mutated: {properties!r} != {snapshot!r}"
+    )
+
+
+def test_arrange_cols_swaps_id_in_returned_columns():
+    """`'id'` in `properties` should still resolve to the output_id column."""
+    df = pd.DataFrame({"id": ["a"], "value": [1.0]})
+    result = _arrange_cols(df, ["id", "value"], output_id="daily_id")
+    assert "daily_id" in result.columns
+    assert "id" not in result.columns
+
+
+def test_arrange_cols_keeps_geometry_when_present():
+    """Geometry must come along even if the caller didn't list it."""
+    df = pd.DataFrame({"id": ["a"], "value": [1.0], "geometry": ["p1"]})
+    result = _arrange_cols(df, ["value"], output_id="daily_id")
+    assert "geometry" in result.columns


### PR DESCRIPTION
## Summary

`_arrange_cols` did `properties.append("geometry")` and `properties[properties.index("id")] = output_id` in place. Calling any getter twice with the same `properties=[...]` list therefore caused that list to grow unboundedly and have `id` rewritten across calls — a real action-at-a-distance defect for any user code that re-uses a `properties` list across requests.

This PR takes a local copy of the list and mutates that. The caller's list is untouched.

## Minimal reproducible example

A common pattern: define a `properties` list once and reuse it for two different getters.

```python
from dataretrieval.waterdata import get_daily, get_continuous

cols = ["id", "monitoring_location_id", "value", "time"]

# Call 1 - get_daily mutates `cols` in place
get_daily(
    monitoring_location_id="USGS-05427718",
    parameter_code="00060",
    time="2025-01-01/2025-01-02",
    properties=cols,
)
# cols is now ['daily_id', 'monitoring_location_id', 'value', 'time', 'geometry']

# Call 2 - same list, different getter, hits the live API with the
# already-mutated names
get_continuous(
    monitoring_location_id="USGS-06904500",
    parameter_code="00065",
    time="2025-01-01T00:00:00Z/2025-01-01T01:00:00Z",
    properties=cols,
)
# RuntimeError: 400: InvalidParameterValue. unknown properties specified.
```

The `'id'` -> `'daily_id'` rewrite from call 1 leaks into the wire request for `get_continuous`, which doesn't recognize `daily_id` as a valid property and rejects the entire request. With this PR, the same code succeeds — `cols` is byte-for-byte unchanged after each call. The same defect surfaces in three more everyday patterns (loop over sites with shared list, `get_continuous` -> `get_daily`, `get_daily` -> `get_monitoring_locations`); all four fail with 400 against the live API on `main` and all four succeed on this branch.

## Test plan
- [x] Three new regression tests in `tests/waterdata_utils_test.py`: caller list is unchanged after two consecutive calls; `'id'` still resolves to the `output_id` column in the result; `geometry` is still tacked on when present in the response.
- [x] Existing tests in the file still pass.
- [x] Full local test suite passes (with `API_USGS_PAT` set).
- [x] Verified live against `api.waterdata.usgs.gov` that the four cross-getter / loop scenarios above fail with 400 on `main` and succeed on this branch.

## Related PRs

Other open PRs in this bug-review series that touch `dataretrieval/waterdata/utils.py` (different functions, no functional conflicts):
- **#247** — `_format_api_dates` accept ISO 8601.
- **#255** — `get_stats_data` preserve geometry across continuation pages.
- **#257** — `_handle_stats_nesting` tolerate missing drop columns.