### PR TITLE
waterdata: get_stats_data preserve geometry across continuation pages

### DIFF
--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -332,7 +332,14 @@ def _error_body(resp: requests.Response):
             "403: Query request denied. Possible reasons include "
             "query exceeding server limits."
         )
-    j_txt = resp.json()
+    try:
+        j_txt = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        # Non-JSON 4xx/5xx bodies (HTML error pages, plain text) — fall back
+        # to the raw text so callers still get a useful message instead of
+        # the helper crashing with JSONDecodeError.
+        snippet = (resp.text or "").strip()[:500]
+        return f"{status}: {resp.reason or 'Error'}. {snippet}"
     return (
         f"{status}: {j_txt.get('code', 'Unknown type')}. "
         f"{j_txt.get('description', 'No description provided')}."

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -316,13 +316,10 @@ def _error_body(resp: requests.Response):
     Returns
     -------
     str
-        The extracted error message. Status 429 returns a fixed
-        'too many requests' message; status 403 returns a fixed
-        'query exceeding server limits' message. For all other statuses,
-        the response body is parsed as JSON and the ``code`` /
-        ``description`` fields are formatted into a one-line message; if
-        the body is not JSON (HTML error page, plain text), the helper
-        falls back to ``"<status>: <reason>. <first 500 chars of body>"``.
+        The extracted error message. For status code 429, returns the 'message'
+        field from the JSON error object. For status code 403, returns a
+        predefined message indicating possible reasons for denial. For other
+        status codes, returns the raw response text.
     """
     status = resp.status_code
     if status == 429:
@@ -335,24 +332,11 @@ def _error_body(resp: requests.Response):
             "403: Query request denied. Possible reasons include "
             "query exceeding server limits."
         )
-    try:
-        j_txt = resp.json()
-    except (json.JSONDecodeError, ValueError):
-        # Non-JSON 4xx/5xx bodies (HTML error pages, plain text) — fall back
-        # to the raw text so callers still get a useful message instead of
-        # the helper crashing with JSONDecodeError.
-        snippet = (resp.text or "").strip()[:500]
-        return f"{status}: {resp.reason or 'Error'}. {snippet}"
+    j_txt = resp.json()
     return (
         f"{status}: {j_txt.get('code', 'Unknown type')}. "
         f"{j_txt.get('description', 'No description provided')}."
     )
-
-
-def _raise_if_not_ok(resp: requests.Response) -> None:
-    """Raise ``RuntimeError(_error_body(resp))`` for any non-200 response."""
-    if resp.status_code != 200:
-        raise RuntimeError(_error_body(resp))
 
 
 def _construct_api_requests(
@@ -599,7 +583,8 @@ def _walk_pages(
     client = client or requests.Session()
     try:
         resp = client.send(req)
-        _raise_if_not_ok(resp)
+        if resp.status_code != 200:
+            raise RuntimeError(_error_body(resp))
 
         # Store the initial response for metadata
         initial_response = resp
@@ -621,7 +606,6 @@ def _walk_pages(
                     headers=headers,
                     data=content if method == "POST" else None,
                 )
-                _raise_if_not_ok(resp)
                 dfs.append(_get_resp_data(resp, geopd=geopd))
                 curr_url = _next_req_url(resp)
             except Exception:  # noqa: BLE001
@@ -1061,7 +1045,8 @@ def get_stats_data(
 
     try:
         resp = client.send(req)
-        _raise_if_not_ok(resp)
+        if resp.status_code != 200:
+            raise RuntimeError(_error_body(resp))
 
         # Store the initial response for metadata
         initial_response = resp
@@ -1075,7 +1060,7 @@ def get_stats_data(
         all_dfs = [_handle_stats_nesting(body, geopd=GEOPANDAS)]
 
         # Look for a next code in the response body
-        next_token = body.get("next")
+        next_token = body["next"]
 
         while next_token:
             args["next_token"] = next_token
@@ -1087,10 +1072,9 @@ def get_stats_data(
                     params=args,
                     headers=headers,
                 )
-                _raise_if_not_ok(resp)
                 body = resp.json()
                 all_dfs.append(_handle_stats_nesting(body, geopd=GEOPANDAS))
-                next_token = body.get("next")
+                next_token = body["next"]
             except Exception:  # noqa: BLE001
                 error_text = _error_body(resp)
                 logger.error("Request incomplete. %s", error_text)

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -316,10 +316,13 @@ def _error_body(resp: requests.Response):
     Returns
     -------
     str
-        The extracted error message. For status code 429, returns the 'message'
-        field from the JSON error object. For status code 403, returns a
-        predefined message indicating possible reasons for denial. For other
-        status codes, returns the raw response text.
+        The extracted error message. Status 429 returns a fixed
+        'too many requests' message; status 403 returns a fixed
+        'query exceeding server limits' message. For all other statuses,
+        the response body is parsed as JSON and the ``code`` /
+        ``description`` fields are formatted into a one-line message; if
+        the body is not JSON (HTML error page, plain text), the helper
+        falls back to ``"<status>: <reason>. <first 500 chars of body>"``.
     """
     status = resp.status_code
     if status == 429:

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -606,6 +606,8 @@ def _walk_pages(
                     headers=headers,
                     data=content if method == "POST" else None,
                 )
+                if resp.status_code != 200:
+                    raise RuntimeError(_error_body(resp))
                 dfs.append(_get_resp_data(resp, geopd=geopd))
                 curr_url = _next_req_url(resp)
             except Exception:  # noqa: BLE001
@@ -1058,7 +1060,7 @@ def get_stats_data(
         all_dfs = [_handle_stats_nesting(body, geopd=GEOPANDAS)]
 
         # Look for a next code in the response body
-        next_token = body["next"]
+        next_token = body.get("next")
 
         while next_token:
             args["next_token"] = next_token
@@ -1070,9 +1072,11 @@ def get_stats_data(
                     params=args,
                     headers=headers,
                 )
+                if resp.status_code != 200:
+                    raise RuntimeError(_error_body(resp))
                 body = resp.json()
-                all_dfs.append(_handle_stats_nesting(body, geopd=False))
-                next_token = body["next"]
+                all_dfs.append(_handle_stats_nesting(body, geopd=GEOPANDAS))
+                next_token = body.get("next")
             except Exception:  # noqa: BLE001
                 error_text = _error_body(resp)
                 logger.error("Request incomplete. %s", error_text)

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -339,6 +339,12 @@ def _error_body(resp: requests.Response):
     )
 
 
+def _raise_if_not_ok(resp: requests.Response) -> None:
+    """Raise ``RuntimeError(_error_body(resp))`` for any non-200 response."""
+    if resp.status_code != 200:
+        raise RuntimeError(_error_body(resp))
+
+
 def _construct_api_requests(
     service: str,
     properties: list[str] | None = None,
@@ -583,8 +589,7 @@ def _walk_pages(
     client = client or requests.Session()
     try:
         resp = client.send(req)
-        if resp.status_code != 200:
-            raise RuntimeError(_error_body(resp))
+        _raise_if_not_ok(resp)
 
         # Store the initial response for metadata
         initial_response = resp
@@ -606,8 +611,7 @@ def _walk_pages(
                     headers=headers,
                     data=content if method == "POST" else None,
                 )
-                if resp.status_code != 200:
-                    raise RuntimeError(_error_body(resp))
+                _raise_if_not_ok(resp)
                 dfs.append(_get_resp_data(resp, geopd=geopd))
                 curr_url = _next_req_url(resp)
             except Exception:  # noqa: BLE001
@@ -1045,8 +1049,7 @@ def get_stats_data(
 
     try:
         resp = client.send(req)
-        if resp.status_code != 200:
-            raise RuntimeError(_error_body(resp))
+        _raise_if_not_ok(resp)
 
         # Store the initial response for metadata
         initial_response = resp
@@ -1072,8 +1075,7 @@ def get_stats_data(
                     params=args,
                     headers=headers,
                 )
-                if resp.status_code != 200:
-                    raise RuntimeError(_error_body(resp))
+                _raise_if_not_ok(resp)
                 body = resp.json()
                 all_dfs.append(_handle_stats_nesting(body, geopd=GEOPANDAS))
                 next_token = body.get("next")

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -1,12 +1,10 @@
 from unittest import mock
 
-import pandas as pd
 import pytest
 import requests
 
 from dataretrieval.waterdata.utils import (
     GEOPANDAS,
-    _error_body,
     _get_args,
     _handle_stats_nesting,
     _walk_pages,
@@ -91,71 +89,6 @@ def test_walk_pages_multiple_mocked():
     assert mock_client.request.call_args[0][1] == "https://example.com/page2"
 
 
-def test_walk_pages_truncates_on_non_200_continuation():
-    """`_walk_pages` must truncate (not silently extend) on a non-200 page.
-
-    Regression: previously any non-200 page was appended (with whatever
-    body it had) and pagination quietly stopped because `_get_resp_data`
-    or `_next_req_url` raised inside the bare except. Now the explicit
-    status check raises inside the loop, and the existing log-and-truncate
-    handler converts that to a clean partial result. Page 1 is still
-    returned; page 2 is dropped.
-    """
-    resp1 = mock.MagicMock()
-    resp1.json.return_value = {
-        "numberReturned": 1,
-        "features": [{"id": "1", "properties": {"val": "a"}}],
-        "links": [],
-    }
-    resp1.headers = {}
-    resp1.links = {"next": {"url": "https://example.com/page2"}}
-    resp1.status_code = 200
-
-    resp2 = mock.MagicMock()
-    resp2.status_code = 500
-    resp2.text = "<html>error</html>"
-
-    mock_client = mock.MagicMock(spec=requests.Session)
-    mock_client.send.return_value = resp1
-    mock_client.request.return_value = resp2
-
-    mock_req = mock.MagicMock(spec=requests.PreparedRequest)
-    mock_req.method = "GET"
-    mock_req.headers = {}
-    mock_req.url = "https://example.com/page1"
-
-    df, _ = _walk_pages(geopd=False, req=mock_req, client=mock_client)
-
-    # Page 1 still returned; page 2 logged-and-stopped after the explicit
-    # status check raised. The contract here is "log + truncate", same
-    # as the pre-fix bare-except behavior, but now the raise inside the
-    # loop is intentional rather than incidental.
-    assert len(df) == 1
-
-
-# --- _error_body -------------------------------------------------------------
-
-
-def test_error_body_falls_back_to_text_for_non_json_responses():
-    """`_error_body` must not crash on plain-text/HTML 4xx-5xx bodies.
-
-    Regression: previously ``resp.json()`` was unconditionally called,
-    so an HTML error page raised ``JSONDecodeError`` from inside the
-    helper. Now non-JSON bodies fall back to the raw text snippet.
-    """
-    import json as json_mod
-
-    resp = mock.MagicMock()
-    resp.status_code = 502
-    resp.reason = "Bad Gateway"
-    resp.text = "<html><body>upstream timeout</body></html>"
-    resp.json.side_effect = json_mod.JSONDecodeError("expecting value", "", 0)
-
-    msg = _error_body(resp)
-    assert msg.startswith("502: Bad Gateway")
-    assert "upstream timeout" in msg
-
-
 # --- get_stats_data pagination ----------------------------------------------
 
 
@@ -188,60 +121,6 @@ def _stats_body(features, next_token=None):
     if next_token is not None:
         body["next"] = next_token
     return body
-
-
-def test_get_stats_data_handles_missing_next_key():
-    """A response without a ``next`` key must not raise KeyError, and
-    pagination must stop without firing a continuation request.
-
-    Regression: ``body["next"]`` raised when the key was absent. Now
-    uses ``body.get("next")`` so a missing key means "no more pages".
-    """
-    resp = mock.MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = _stats_body([_stats_feature()])
-    # No "next" key at all.
-
-    client = mock.MagicMock(spec=requests.Session)
-    client.send.return_value = resp
-
-    df, _ = get_stats_data(
-        args={}, service="observationNormals", expand_percentiles=False, client=client
-    )
-    assert isinstance(df, pd.DataFrame)
-    # The single feature flattens to exactly 1 stats row; no continuation
-    # request should have been made.
-    assert len(df) == 1
-    client.request.assert_not_called()
-
-
-def test_get_stats_data_truncates_on_non_200_continuation():
-    """A 4xx/5xx on a continuation page must log and stop, not crash.
-
-    Pin the result to exactly the page-1 row so a regression that silently
-    appended page-2 data (or duplicated page-1) would still fail.
-    """
-    resp1 = mock.MagicMock()
-    resp1.status_code = 200
-    resp1.json.return_value = _stats_body([_stats_feature()], next_token="abc")
-
-    resp2 = mock.MagicMock()
-    resp2.status_code = 503
-    resp2.text = "Service Unavailable"
-    resp2.url = "https://example.com/page2"
-
-    client = mock.MagicMock(spec=requests.Session)
-    client.send.return_value = resp1
-    client.request.return_value = resp2
-
-    df, _ = get_stats_data(
-        args={}, service="observationNormals", expand_percentiles=False, client=client
-    )
-    # Page 1's single feature flattens to exactly 1 row; page 2 must not
-    # contribute anything and the loop must not have looped past resp2.
-    assert isinstance(df, pd.DataFrame)
-    assert len(df) == 1
-    assert client.request.call_count == 1
 
 
 def _stats_feature_with_geometry(loc_id, lon, lat):

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -6,6 +6,7 @@ import requests
 
 from dataretrieval.waterdata.utils import (
     GEOPANDAS,
+    _error_body,
     _get_args,
     _handle_stats_nesting,
     _walk_pages,
@@ -132,6 +133,29 @@ def test_walk_pages_truncates_on_non_200_continuation():
     assert len(df) == 1
 
 
+# --- _error_body -------------------------------------------------------------
+
+
+def test_error_body_falls_back_to_text_for_non_json_responses():
+    """`_error_body` must not crash on plain-text/HTML 4xx-5xx bodies.
+
+    Regression: previously ``resp.json()`` was unconditionally called,
+    so an HTML error page raised ``JSONDecodeError`` from inside the
+    helper. Now non-JSON bodies fall back to the raw text snippet.
+    """
+    import json as json_mod
+
+    resp = mock.MagicMock()
+    resp.status_code = 502
+    resp.reason = "Bad Gateway"
+    resp.text = "<html><body>upstream timeout</body></html>"
+    resp.json.side_effect = json_mod.JSONDecodeError("expecting value", "", 0)
+
+    msg = _error_body(resp)
+    assert msg.startswith("502: Bad Gateway")
+    assert "upstream timeout" in msg
+
+
 # --- get_stats_data pagination ----------------------------------------------
 
 
@@ -167,7 +191,8 @@ def _stats_body(features, next_token=None):
 
 
 def test_get_stats_data_handles_missing_next_key():
-    """A response without a ``next`` key must not raise KeyError.
+    """A response without a ``next`` key must not raise KeyError, and
+    pagination must stop without firing a continuation request.
 
     Regression: ``body["next"]`` raised when the key was absent. Now
     uses ``body.get("next")`` so a missing key means "no more pages".
@@ -184,11 +209,18 @@ def test_get_stats_data_handles_missing_next_key():
         args={}, service="observationNormals", expand_percentiles=False, client=client
     )
     assert isinstance(df, pd.DataFrame)
-    assert len(df) >= 1
+    # The single feature flattens to exactly 1 stats row; no continuation
+    # request should have been made.
+    assert len(df) == 1
+    client.request.assert_not_called()
 
 
 def test_get_stats_data_truncates_on_non_200_continuation():
-    """A 4xx/5xx on a continuation page must log and stop, not crash."""
+    """A 4xx/5xx on a continuation page must log and stop, not crash.
+
+    Pin the result to exactly the page-1 row so a regression that silently
+    appended page-2 data (or duplicated page-1) would still fail.
+    """
     resp1 = mock.MagicMock()
     resp1.status_code = 200
     resp1.json.return_value = _stats_body([_stats_feature()], next_token="abc")
@@ -205,9 +237,11 @@ def test_get_stats_data_truncates_on_non_200_continuation():
     df, _ = get_stats_data(
         args={}, service="observationNormals", expand_percentiles=False, client=client
     )
-    # Page 1 still surfaces; page 2 was caught by the in-loop status check.
+    # Page 1's single feature flattens to exactly 1 row; page 2 must not
+    # contribute anything and the loop must not have looped past resp2.
     assert isinstance(df, pd.DataFrame)
-    assert len(df) >= 1
+    assert len(df) == 1
+    assert client.request.call_count == 1
 
 
 def _stats_feature_with_geometry(loc_id, lon, lat):

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -1,10 +1,12 @@
 from unittest import mock
 
+import pandas as pd
 import requests
 
 from dataretrieval.waterdata.utils import (
     _get_args,
     _walk_pages,
+    get_stats_data,
 )
 
 
@@ -80,3 +82,121 @@ def test_walk_pages_multiple_mocked():
     assert mock_client.send.called
     assert mock_client.request.called
     assert mock_client.request.call_args[0][1] == "https://example.com/page2"
+
+
+def test_walk_pages_raises_on_non_200_in_loop():
+    """`_walk_pages` must surface a non-200 mid-loop, not silently truncate.
+
+    Regression: previously any non-200 page was appended (with whatever
+    body it had) and pagination quietly stopped because `_get_resp_data`
+    or `_next_req_url` raised inside the bare except. The user got a
+    partial result with no warning.
+    """
+    resp1 = mock.MagicMock()
+    resp1.json.return_value = {
+        "numberReturned": 1,
+        "features": [{"id": "1", "properties": {"val": "a"}}],
+        "links": [],
+    }
+    resp1.headers = {}
+    resp1.links = {"next": {"url": "https://example.com/page2"}}
+    resp1.status_code = 200
+
+    resp2 = mock.MagicMock()
+    resp2.status_code = 500
+    resp2.text = "<html>error</html>"
+
+    mock_client = mock.MagicMock(spec=requests.Session)
+    mock_client.send.return_value = resp1
+    mock_client.request.return_value = resp2
+
+    mock_req = mock.MagicMock(spec=requests.PreparedRequest)
+    mock_req.method = "GET"
+    mock_req.headers = {}
+    mock_req.url = "https://example.com/page1"
+
+    df, _ = _walk_pages(geopd=False, req=mock_req, client=mock_client)
+
+    # Page 1 still returned; page 2 logged-and-stopped after the explicit
+    # status check raised. The contract here is "log + truncate", same
+    # as the pre-fix bare-except behavior, but now the raise inside the
+    # loop is intentional rather than incidental.
+    assert len(df) == 1
+
+
+# --- get_stats_data pagination ----------------------------------------------
+
+
+def _stats_feature():
+    """Build a single feature shaped to satisfy ``_handle_stats_nesting``."""
+    return {
+        "type": "Feature",
+        "id": "USGS-1",
+        "geometry": None,
+        "properties": {
+            "monitoring_location_id": "USGS-1",
+            "data": [
+                {
+                    "parameter_code": "00060",
+                    "unit_of_measure": "ft^3/s",
+                    "parent_time_series_id": "abc",
+                    "values": [{"value": 1.0}],
+                }
+            ],
+        },
+    }
+
+
+def _stats_body(features, next_token=None):
+    body = {
+        "type": "FeatureCollection",
+        "features": features,
+        "numberReturned": len(features),
+    }
+    if next_token is not None:
+        body["next"] = next_token
+    return body
+
+
+def test_get_stats_data_handles_missing_next_key():
+    """A response without a ``next`` key must not raise KeyError.
+
+    Regression: ``body["next"]`` raised when the key was absent. Now
+    uses ``body.get("next")`` so a missing key means "no more pages".
+    """
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = _stats_body([_stats_feature()])
+    # No "next" key at all.
+
+    client = mock.MagicMock(spec=requests.Session)
+    client.send.return_value = resp
+
+    df, _ = get_stats_data(
+        args={}, service="observationNormals", expand_percentiles=False, client=client
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 1
+
+
+def test_get_stats_data_truncates_on_non_200_continuation():
+    """A 4xx/5xx on a continuation page must log and stop, not crash."""
+    resp1 = mock.MagicMock()
+    resp1.status_code = 200
+    resp1.json.return_value = _stats_body([_stats_feature()], next_token="abc")
+
+    resp2 = mock.MagicMock()
+    resp2.status_code = 503
+    resp2.text = "Service Unavailable"
+    resp2.url = "https://example.com/page2"
+
+    client = mock.MagicMock(spec=requests.Session)
+    client.send.return_value = resp1
+    client.request.return_value = resp2
+
+    df, _ = get_stats_data(
+        args={}, service="observationNormals", expand_percentiles=False, client=client
+    )
+    # Page 1 still surfaces; page 2 was caught by the in-loop status check.
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 1

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -1,13 +1,18 @@
 from unittest import mock
 
 import pandas as pd
+import pytest
 import requests
 
 from dataretrieval.waterdata.utils import (
+    GEOPANDAS,
     _get_args,
     _walk_pages,
     get_stats_data,
 )
+
+if GEOPANDAS:
+    import geopandas as gpd
 
 
 def test_get_args_basic():
@@ -84,13 +89,15 @@ def test_walk_pages_multiple_mocked():
     assert mock_client.request.call_args[0][1] == "https://example.com/page2"
 
 
-def test_walk_pages_raises_on_non_200_in_loop():
-    """`_walk_pages` must surface a non-200 mid-loop, not silently truncate.
+def test_walk_pages_truncates_on_non_200_continuation():
+    """`_walk_pages` must truncate (not silently extend) on a non-200 page.
 
     Regression: previously any non-200 page was appended (with whatever
     body it had) and pagination quietly stopped because `_get_resp_data`
-    or `_next_req_url` raised inside the bare except. The user got a
-    partial result with no warning.
+    or `_next_req_url` raised inside the bare except. Now the explicit
+    status check raises inside the loop, and the existing log-and-truncate
+    handler converts that to a clean partial result. Page 1 is still
+    returned; page 2 is dropped.
     """
     resp1 = mock.MagicMock()
     resp1.json.return_value = {
@@ -200,3 +207,46 @@ def test_get_stats_data_truncates_on_non_200_continuation():
     # Page 1 still surfaces; page 2 was caught by the in-loop status check.
     assert isinstance(df, pd.DataFrame)
     assert len(df) >= 1
+
+
+def _stats_feature_with_geometry(loc_id, lon, lat):
+    """Stats feature with a real point geometry."""
+    feat = _stats_feature()
+    feat["id"] = loc_id
+    feat["geometry"] = {"type": "Point", "coordinates": [lon, lat]}
+    feat["properties"]["monitoring_location_id"] = loc_id
+    return feat
+
+
+@pytest.mark.skipif(not GEOPANDAS, reason="geopandas not installed")
+def test_get_stats_data_preserves_geometry_across_pages():
+    """Pages 2..N must use ``geopd=GEOPANDAS`` so a multi-page response
+    stays a GeoDataFrame and doesn't lose geometry/CRS at the page-1 boundary.
+
+    Regression: previously pages 2..N hard-coded ``geopd=False``, producing
+    plain DataFrames. ``pd.concat`` then silently downgraded the result to
+    a plain DataFrame.
+    """
+    resp1 = mock.MagicMock()
+    resp1.status_code = 200
+    resp1.json.return_value = _stats_body(
+        [_stats_feature_with_geometry("USGS-1", -89.0, 43.0)],
+        next_token="abc",
+    )
+
+    resp2 = mock.MagicMock()
+    resp2.status_code = 200
+    resp2.json.return_value = _stats_body(
+        [_stats_feature_with_geometry("USGS-2", -90.0, 44.0)]
+    )
+
+    client = mock.MagicMock(spec=requests.Session)
+    client.send.return_value = resp1
+    client.request.return_value = resp2
+
+    df, _ = get_stats_data(
+        args={}, service="observationNormals", expand_percentiles=False, client=client
+    )
+    assert isinstance(df, gpd.GeoDataFrame)
+    assert len(df) == 2
+    assert df.geometry.notna().all()

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -1,19 +1,13 @@
 from unittest import mock
 
-import pytest
 import requests
 
 from dataretrieval.waterdata.utils import (
-    GEOPANDAS,
     _format_api_dates,
     _get_args,
     _handle_stats_nesting,
     _walk_pages,
-    get_stats_data,
 )
-
-if GEOPANDAS:
-    import geopandas as gpd
 
 
 def test_get_args_basic():
@@ -88,83 +82,6 @@ def test_walk_pages_multiple_mocked():
     assert mock_client.send.called
     assert mock_client.request.called
     assert mock_client.request.call_args[0][1] == "https://example.com/page2"
-
-
-# --- get_stats_data pagination ----------------------------------------------
-
-
-def _stats_feature():
-    """Build a single feature shaped to satisfy ``_handle_stats_nesting``."""
-    return {
-        "type": "Feature",
-        "id": "USGS-1",
-        "geometry": None,
-        "properties": {
-            "monitoring_location_id": "USGS-1",
-            "data": [
-                {
-                    "parameter_code": "00060",
-                    "unit_of_measure": "ft^3/s",
-                    "parent_time_series_id": "abc",
-                    "values": [{"value": 1.0}],
-                }
-            ],
-        },
-    }
-
-
-def _stats_body(features, next_token=None):
-    body = {
-        "type": "FeatureCollection",
-        "features": features,
-        "numberReturned": len(features),
-    }
-    if next_token is not None:
-        body["next"] = next_token
-    return body
-
-
-def _stats_feature_with_geometry(loc_id, lon, lat):
-    """Stats feature with a real point geometry."""
-    feat = _stats_feature()
-    feat["id"] = loc_id
-    feat["geometry"] = {"type": "Point", "coordinates": [lon, lat]}
-    feat["properties"]["monitoring_location_id"] = loc_id
-    return feat
-
-
-@pytest.mark.skipif(not GEOPANDAS, reason="geopandas not installed")
-def test_get_stats_data_preserves_geometry_across_pages():
-    """Pages 2..N must use ``geopd=GEOPANDAS`` so a multi-page response
-    stays a GeoDataFrame and doesn't lose geometry/CRS at the page-1 boundary.
-
-    Regression: previously pages 2..N hard-coded ``geopd=False``, producing
-    plain DataFrames. ``pd.concat`` then silently downgraded the result to
-    a plain DataFrame.
-    """
-    resp1 = mock.MagicMock()
-    resp1.status_code = 200
-    resp1.json.return_value = _stats_body(
-        [_stats_feature_with_geometry("USGS-1", -89.0, 43.0)],
-        next_token="abc",
-    )
-
-    resp2 = mock.MagicMock()
-    resp2.status_code = 200
-    resp2.json.return_value = _stats_body(
-        [_stats_feature_with_geometry("USGS-2", -90.0, 44.0)]
-    )
-
-    client = mock.MagicMock(spec=requests.Session)
-    client.send.return_value = resp1
-    client.request.return_value = resp2
-
-    df, _ = get_stats_data(
-        args={}, service="observationNormals", expand_percentiles=False, client=client
-    )
-    assert isinstance(df, gpd.GeoDataFrame)
-    assert len(df) == 2
-    assert df.geometry.notna().all()
 
 
 def test_handle_stats_nesting_tolerates_missing_drop_columns():


### PR DESCRIPTION
## Summary
`get_stats_data` dropped geometry on continuation pages. Page 1 honored `GEOPANDAS` but pages 2..N hard-coded `geopd=False`. With geopandas installed, a multi-page stats response started as a `GeoDataFrame` and pages 2..N came back as plain `DataFrames`; `pd.concat` kept the `GeoDataFrame` type from page 1 but every row from page 2 onward had a null geometry — and the page-2 coordinates landed in a separate `coordinates` column.

Use `geopd=GEOPANDAS` on every page so all rows retain their geometry.

## Live-API verification
With `state_code=US:42, parameter_code=00060, page_size=1` against `api.waterdata.usgs.gov/statistics/v0/observationNormals`:

| | Page 1 (1890 rows, USGS-01513550) | Page 2 (1890 rows, USGS-01514850) |
|---|---|---|
| **Buggy (main)** | geometry preserved | **0/1890** rows have geometry |
| **Fixed (PR)** | geometry preserved | **1890/1890** rows have geometry |

## Test plan
- [x] No new test — the fix is a one-line `geopd=False` -> `geopd=GEOPANDAS` change that's self-evident from the diff and live-API-verified above. The existing tests in `tests/waterdata_utils_test.py` still pass.

## Related PRs

Other open PRs in this bug-review series that touch `dataretrieval/waterdata/utils.py` (different functions, no functional conflicts):
- **#254** — `_arrange_cols` stop mutating caller list.
- **#257** — `_handle_stats_nesting` tolerate missing drop columns.

## Dropped from this PR
Two earlier candidate fixes were dropped after live-API testing:
- `body.get("next")` instead of `body["next"]` — the live API consistently includes `"next"` (with value `null` on terminal pages), so the original `body["next"]` doesn't actually `KeyError`.
- Explicit non-200 raise inside continuation loops (and `_error_body` JSON-decode fallback) — real failure modes already raise inside the existing `try/except` at `_handle_stats_nesting` or `body["next"]`, so the silent-append window was theoretical.