### PR TITLE
Polish wqp.py: silence prints, fix exception shape, fix typos

### DIFF
--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -131,9 +131,9 @@ def get_results(
             "dataProfile" in kwargs
             and kwargs["dataProfile"] not in result_profiles_legacy
         ):
-            raise TypeError(
-                f"dataProfile {kwargs['dataProfile']} is not a legacy profile.",
-                f"Valid options are {result_profiles_legacy}.",
+            raise ValueError(
+                f"dataProfile {kwargs['dataProfile']} is not a legacy profile. "
+                f"Valid options are {result_profiles_legacy}."
             )
 
         url = wqp_url("Result")
@@ -143,9 +143,9 @@ def get_results(
             "dataProfile" in kwargs
             and kwargs["dataProfile"] not in result_profiles_wqx3
         ):
-            raise TypeError(
-                f"dataProfile {kwargs['dataProfile']} is not a valid WQX3.0"
-                f"profile. Valid options are {result_profiles_wqx3}.",
+            raise ValueError(
+                f"dataProfile {kwargs['dataProfile']} is not a valid WQX3.0 "
+                f"profile. Valid options are {result_profiles_wqx3}."
             )
         else:
             kwargs["dataProfile"] = "fullPhysChem"
@@ -255,15 +255,9 @@ def what_organizations(
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        url = wqp_url("Organization")
-    else:
-        warnings.warn(
-            "WQX3.0 profile not available, returning legacy profile.",
-            UserWarning,
-            stacklevel=2,
-        )
-        url = wqp_url("Organization")
+    if not legacy:
+        _warn_wqx3_unavailable()
+    url = wqp_url("Organization")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -310,15 +304,9 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        url = wqp_url("Project")
-    else:
-        warnings.warn(
-            "WQX3.0 profile not available, returning legacy profile.",
-            UserWarning,
-            stacklevel=2,
-        )
-        url = wqp_url("Project")
+    if not legacy:
+        _warn_wqx3_unavailable()
+    url = wqp_url("Project")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -440,15 +428,9 @@ def what_detection_limits(
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        url = wqp_url("ResultDetectionQuantitationLimit")
-    else:
-        warnings.warn(
-            "WQX3.0 profile not available, returning legacy profile.",
-            UserWarning,
-            stacklevel=2,
-        )
-        url = wqp_url("ResultDetectionQuantitationLimit")
+    if not legacy:
+        _warn_wqx3_unavailable()
+    url = wqp_url("ResultDetectionQuantitationLimit")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -499,15 +481,9 @@ def what_habitat_metrics(
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        url = wqp_url("BiologicalMetric")
-    else:
-        warnings.warn(
-            "WQX3.0 profile not available, returning legacy profile.",
-            UserWarning,
-            stacklevel=2,
-        )
-        url = wqp_url("BiologicalMetric")
+    if not legacy:
+        _warn_wqx3_unavailable()
+    url = wqp_url("BiologicalMetric")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -559,15 +535,9 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        url = wqp_url("ProjectMonitoringLocationWeighting")
-    else:
-        warnings.warn(
-            "WQX3.0 profile not available, returning legacy profile.",
-            UserWarning,
-            stacklevel=2,
-        )
-        url = wqp_url("ProjectMonitoringLocationWeighting")
+    if not legacy:
+        _warn_wqx3_unavailable()
+    url = wqp_url("ProjectMonitoringLocationWeighting")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -619,15 +589,9 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
 
     kwargs = _check_kwargs(kwargs)
 
-    if legacy is True:
-        url = wqp_url("ActivityMetric")
-    else:
-        warnings.warn(
-            "WQX3.0 profile not available, returning legacy profile.",
-            UserWarning,
-            stacklevel=2,
-        )
-        url = wqp_url("ActivityMetric")
+    if not legacy:
+        _warn_wqx3_unavailable()
+    url = wqp_url("ActivityMetric")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -744,3 +708,11 @@ def _warn_legacy_use():
         "will remove this warning."
     )
     warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+
+def _warn_wqx3_unavailable():
+    warnings.warn(
+        "WQX3.0 profile not available, returning legacy profile.",
+        UserWarning,
+        stacklevel=3,
+    )

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -255,9 +255,7 @@ def what_organizations(
 
     kwargs = _check_kwargs(kwargs)
 
-    if not legacy:
-        _warn_wqx3_unavailable()
-    url = wqp_url("Organization")
+    url = _legacy_only_url("Organization", legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -304,9 +302,7 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
 
     kwargs = _check_kwargs(kwargs)
 
-    if not legacy:
-        _warn_wqx3_unavailable()
-    url = wqp_url("Project")
+    url = _legacy_only_url("Project", legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -428,9 +424,7 @@ def what_detection_limits(
 
     kwargs = _check_kwargs(kwargs)
 
-    if not legacy:
-        _warn_wqx3_unavailable()
-    url = wqp_url("ResultDetectionQuantitationLimit")
+    url = _legacy_only_url("ResultDetectionQuantitationLimit", legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -481,9 +475,7 @@ def what_habitat_metrics(
 
     kwargs = _check_kwargs(kwargs)
 
-    if not legacy:
-        _warn_wqx3_unavailable()
-    url = wqp_url("BiologicalMetric")
+    url = _legacy_only_url("BiologicalMetric", legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -535,9 +527,7 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
 
     kwargs = _check_kwargs(kwargs)
 
-    if not legacy:
-        _warn_wqx3_unavailable()
-    url = wqp_url("ProjectMonitoringLocationWeighting")
+    url = _legacy_only_url("ProjectMonitoringLocationWeighting", legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -589,9 +579,7 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
 
     kwargs = _check_kwargs(kwargs)
 
-    if not legacy:
-        _warn_wqx3_unavailable()
-    url = wqp_url("ActivityMetric")
+    url = _legacy_only_url("ActivityMetric", legacy=legacy)
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
@@ -716,3 +704,20 @@ def _warn_wqx3_unavailable():
         UserWarning,
         stacklevel=3,
     )
+
+
+def _legacy_only_url(service: str, legacy: bool) -> str:
+    """URL builder for WQP services that have no WQX3.0 equivalent.
+
+    When ``legacy=False`` is passed to one of these helpers we emit a
+    ``UserWarning`` explaining the fallback and *also* suppress the legacy
+    ``DeprecationWarning`` that ``wqp_url`` would otherwise raise — its
+    message claims setting ``legacy=False`` removes the warning, which is
+    a lie for endpoints that have no WQX3.0 alternative.
+    """
+    if not legacy:
+        _warn_wqx3_unavailable()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return wqp_url(service)
+    return wqp_url(service)

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -691,6 +691,7 @@ def _warn_legacy_use():
 
 
 def _warn_wqx3_unavailable():
+    # stacklevel=3: warn -> _warn_wqx3_unavailable -> _legacy_only_url -> what_*
     warnings.warn(
         "WQX3.0 profile not available, returning legacy profile.",
         UserWarning,
@@ -707,9 +708,8 @@ def _legacy_only_url(service: str, legacy: bool) -> str:
     message claims setting ``legacy=False`` removes the warning, which is
     a lie for endpoints that have no WQX3.0 alternative.
     """
-    if not legacy:
-        _warn_wqx3_unavailable()
-        with warnings.catch_warnings():
+    with warnings.catch_warnings():
+        if not legacy:
+            _warn_wqx3_unavailable()
             warnings.simplefilter("ignore", DeprecationWarning)
-            return wqp_url(service)
-    return wqp_url(service)
+        return wqp_url(service)

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -131,9 +131,9 @@ def get_results(
             "dataProfile" in kwargs
             and kwargs["dataProfile"] not in result_profiles_legacy
         ):
-            raise ValueError(
-                f"dataProfile {kwargs['dataProfile']} is not a legacy profile. "
-                f"Valid options are {result_profiles_legacy}."
+            raise TypeError(
+                f"dataProfile {kwargs['dataProfile']} is not a legacy profile.",
+                f"Valid options are {result_profiles_legacy}.",
             )
 
         url = wqp_url("Result")
@@ -143,9 +143,9 @@ def get_results(
             "dataProfile" in kwargs
             and kwargs["dataProfile"] not in result_profiles_wqx3
         ):
-            raise ValueError(
-                f"dataProfile {kwargs['dataProfile']} is not a valid WQX3.0 "
-                f"profile. Valid options are {result_profiles_wqx3}."
+            raise TypeError(
+                f"dataProfile {kwargs['dataProfile']} is not a valid WQX3.0"
+                f"profile. Valid options are {result_profiles_wqx3}.",
             )
         else:
             kwargs["dataProfile"] = "fullPhysChem"

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -258,7 +258,11 @@ def what_organizations(
     if legacy is True:
         url = wqp_url("Organization")
     else:
-        print("WQX3.0 profile not available, returning legacy profile.")
+        warnings.warn(
+            "WQX3.0 profile not available, returning legacy profile.",
+            UserWarning,
+            stacklevel=2,
+        )
         url = wqp_url("Organization")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
@@ -309,7 +313,11 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
     if legacy is True:
         url = wqp_url("Project")
     else:
-        print("WQX3.0 profile not available, returning legacy profile.")
+        warnings.warn(
+            "WQX3.0 profile not available, returning legacy profile.",
+            UserWarning,
+            stacklevel=2,
+        )
         url = wqp_url("Project")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
@@ -435,7 +443,11 @@ def what_detection_limits(
     if legacy is True:
         url = wqp_url("ResultDetectionQuantitationLimit")
     else:
-        print("WQX3.0 profile not available, returning legacy profile.")
+        warnings.warn(
+            "WQX3.0 profile not available, returning legacy profile.",
+            UserWarning,
+            stacklevel=2,
+        )
         url = wqp_url("ResultDetectionQuantitationLimit")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
@@ -490,7 +502,11 @@ def what_habitat_metrics(
     if legacy is True:
         url = wqp_url("BiologicalMetric")
     else:
-        print("WQX3.0 profile not available, returning legacy profile.")
+        warnings.warn(
+            "WQX3.0 profile not available, returning legacy profile.",
+            UserWarning,
+            stacklevel=2,
+        )
         url = wqp_url("BiologicalMetric")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
@@ -516,7 +532,7 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
     ssl_check : bool
         Check the SSL certificate. Default is True.
     legacy : bool
-        Retrun the legacy WQX data profile. Default is True.
+        Return the legacy WQX data profile. Default is True.
     **kwargs : optional
         Accepts the same parameters as :obj:`dataretrieval.wqp.get_results`
 
@@ -546,7 +562,11 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
     if legacy is True:
         url = wqp_url("ProjectMonitoringLocationWeighting")
     else:
-        print("WQX3.0 profile not available, returning legacy profile.")
+        warnings.warn(
+            "WQX3.0 profile not available, returning legacy profile.",
+            UserWarning,
+            stacklevel=2,
+        )
         url = wqp_url("ProjectMonitoringLocationWeighting")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
@@ -602,12 +622,16 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
     if legacy is True:
         url = wqp_url("ActivityMetric")
     else:
-        print("WQX3.0 profile not available, returning legacy profile.")
+        warnings.warn(
+            "WQX3.0 profile not available, returning legacy profile.",
+            UserWarning,
+            stacklevel=2,
+        )
         url = wqp_url("ActivityMetric")
 
     response = query(url, payload=kwargs, delimiter=";", ssl_check=ssl_check)
 
-    df = pd.read_csv(StringIO(response.text), delimiter=",")
+    df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
     return df, WQP_Metadata(response)
 
@@ -619,9 +643,8 @@ def wqp_url(service):
     _warn_legacy_use()
 
     if service not in services_legacy:
-        raise TypeError(
-            "Legacy service not recognized. Valid options are",
-            f"{services_legacy}.",
+        raise ValueError(
+            f"Legacy service not recognized. Valid options are {services_legacy}."
         )
 
     return f"{base_url}{service}/Search?"
@@ -634,9 +657,8 @@ def wqx3_url(service):
     _warn_wqx3_use()
 
     if service not in services_wqx3:
-        raise TypeError(
-            "WQX3.0 service not recognized. Valid options are",
-            f"{services_wqx3}.",
+        raise ValueError(
+            f"WQX3.0 service not recognized. Valid options are {services_wqx3}."
         )
 
     return f"{base_url}{service}/search?"
@@ -708,7 +730,7 @@ def _check_kwargs(kwargs):
 def _warn_wqx3_use():
     message = (
         "Support for the WQX3.0 profiles is experimental. "
-        "Queries may be slow or fail intermitttently."
+        "Queries may be slow or fail intermittently."
     )
     warnings.warn(message, UserWarning, stacklevel=2)
 

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -14,6 +14,8 @@ from dataretrieval.wqp import (
     what_project_weights,
     what_projects,
     what_sites,
+    wqp_url,
+    wqx3_url,
 )
 
 
@@ -216,3 +218,28 @@ def test_check_kwargs():
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
+
+
+def test_wqp_url_unknown_service_raises_value_error():
+    """Unknown legacy service should raise ValueError with a single readable message."""
+    with pytest.raises(ValueError, match="Legacy service not recognized"):
+        wqp_url("NotAService")
+
+
+def test_wqx3_url_unknown_service_raises_value_error():
+    """Unknown WQX3.0 service should raise ValueError with a single readable message."""
+    with pytest.raises(ValueError, match="WQX3.0 service not recognized"):
+        wqx3_url("NotAService")
+
+
+def test_what_organizations_legacy_false_warns(requests_mock):
+    """legacy=False on what_organizations should emit a warning, not print to stdout."""
+    request_url = (
+        "https://www.waterqualitydata.us/data/Organization/Search?statecode=US%3A34"
+        "&characteristicName=Chloride&mimeType=csv"
+    )
+    mock_request(requests_mock, request_url, "tests/data/wqp_organizations.txt")
+    with pytest.warns(UserWarning, match="WQX3.0 profile not available"):
+        what_organizations(
+            statecode="US:34", characteristicName="Chloride", legacy=False
+        )

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -14,8 +14,6 @@ from dataretrieval.wqp import (
     what_project_weights,
     what_projects,
     what_sites,
-    wqp_url,
-    wqx3_url,
 )
 
 
@@ -218,18 +216,6 @@ def test_check_kwargs():
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
-
-
-def test_wqp_url_unknown_service_raises_value_error():
-    """Unknown legacy service should raise ValueError with a single readable message."""
-    with pytest.raises(ValueError, match="Legacy service not recognized"):
-        wqp_url("NotAService")
-
-
-def test_wqx3_url_unknown_service_raises_value_error():
-    """Unknown WQX3.0 service should raise ValueError with a single readable message."""
-    with pytest.raises(ValueError, match="WQX3.0 service not recognized"):
-        wqx3_url("NotAService")
 
 
 def test_what_organizations_legacy_false_warns(requests_mock):

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -219,13 +219,28 @@ def test_check_kwargs():
 
 
 def test_what_organizations_legacy_false_warns(requests_mock):
-    """legacy=False on what_organizations should emit a warning, not print to stdout."""
+    """legacy=False on a legacy-only helper:
+    - emits the WQX3.0-unavailable UserWarning
+    - suppresses the redundant legacy DeprecationWarning, whose text would
+      misleadingly tell the user that setting legacy=False removes it.
+    """
+    import warnings
+
     request_url = (
         "https://www.waterqualitydata.us/data/Organization/Search?statecode=US%3A34"
         "&characteristicName=Chloride&mimeType=csv"
     )
     mock_request(requests_mock, request_url, "tests/data/wqp_organizations.txt")
-    with pytest.warns(UserWarning, match="WQX3.0 profile not available"):
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
         what_organizations(
             statecode="US:34", characteristicName="Chloride", legacy=False
         )
+
+    user_warnings = [w for w in captured if issubclass(w.category, UserWarning)]
+    deprecation_warnings = [
+        w for w in captured if issubclass(w.category, DeprecationWarning)
+    ]
+    assert any("WQX3.0 profile not available" in str(w.message) for w in user_warnings)
+    assert not any("legacy WQX format" in str(w.message) for w in deprecation_warnings)

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -1,5 +1,4 @@
 import datetime
-import warnings
 
 import pytest
 from pandas import DataFrame
@@ -217,29 +216,6 @@ def test_check_kwargs():
     kwargs = {"mimeType": "foo"}
     with pytest.raises(ValueError):
         kwargs = _check_kwargs(kwargs)
-
-
-def test_what_organizations_legacy_false_warns(requests_mock):
-    """legacy=False on a legacy-only helper warns and suppresses the
-    misleading legacy DeprecationWarning."""
-    request_url = (
-        "https://www.waterqualitydata.us/data/Organization/Search?statecode=US%3A34"
-        "&characteristicName=Chloride&mimeType=csv"
-    )
-    mock_request(requests_mock, request_url, "tests/data/wqp_organizations.txt")
-
-    with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always")
-        what_organizations(
-            statecode="US:34", characteristicName="Chloride", legacy=False
-        )
-
-    user_warnings = [w for w in captured if issubclass(w.category, UserWarning)]
-    deprecation_warnings = [
-        w for w in captured if issubclass(w.category, DeprecationWarning)
-    ]
-    assert any("WQX3.0 profile not available" in str(w.message) for w in user_warnings)
-    assert not any("legacy WQX format" in str(w.message) for w in deprecation_warnings)
 
 
 def test_get_results_wqx3_preserves_user_dataProfile(requests_mock):

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -243,3 +243,15 @@ def test_what_organizations_legacy_false_warns(requests_mock):
         what_organizations(
             statecode="US:34", characteristicName="Chloride", legacy=False
         )
+
+
+def test_get_results_invalid_legacy_dataprofile_raises_value_error():
+    """Invalid legacy dataProfile -> ValueError with single readable message."""
+    with pytest.raises(ValueError, match="is not a legacy profile"):
+        get_results(dataProfile="not_a_real_profile")
+
+
+def test_get_results_invalid_wqx3_dataprofile_raises_value_error():
+    """Invalid WQX3.0 dataProfile -> ValueError with single readable message."""
+    with pytest.raises(ValueError, match="is not a valid WQX3.0 profile"):
+        get_results(legacy=False, dataProfile="not_a_real_profile")

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 import pytest
 from pandas import DataFrame
@@ -219,13 +220,8 @@ def test_check_kwargs():
 
 
 def test_what_organizations_legacy_false_warns(requests_mock):
-    """legacy=False on a legacy-only helper:
-    - emits the WQX3.0-unavailable UserWarning
-    - suppresses the redundant legacy DeprecationWarning, whose text would
-      misleadingly tell the user that setting legacy=False removes it.
-    """
-    import warnings
-
+    """legacy=False on a legacy-only helper warns and suppresses the
+    misleading legacy DeprecationWarning."""
     request_url = (
         "https://www.waterqualitydata.us/data/Organization/Search?statecode=US%3A34"
         "&characteristicName=Chloride&mimeType=csv"

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -243,15 +243,3 @@ def test_what_organizations_legacy_false_warns(requests_mock):
         what_organizations(
             statecode="US:34", characteristicName="Chloride", legacy=False
         )
-
-
-def test_get_results_invalid_legacy_dataprofile_raises_value_error():
-    """Invalid legacy dataProfile -> ValueError with single readable message."""
-    with pytest.raises(ValueError, match="is not a legacy profile"):
-        get_results(dataProfile="not_a_real_profile")
-
-
-def test_get_results_invalid_wqx3_dataprofile_raises_value_error():
-    """Invalid WQX3.0 dataProfile -> ValueError with single readable message."""
-    with pytest.raises(ValueError, match="is not a valid WQX3.0 profile"):
-        get_results(legacy=False, dataProfile="not_a_real_profile")


### PR DESCRIPTION
## Summary

A handful of small, discrete polish fixes in `dataretrieval/wqp.py`:

- **Silence stdout**: Six WQP helpers (`what_organizations`, `what_projects`, `what_detection_limits`, `what_habitat_metrics`, `what_project_weights`, `what_activity_metrics`) had `print("WQX3.0 profile not available, returning legacy profile.")` statements that fire whenever `legacy=False` is passed. Library code shouldn't `print` to stdout; converted to a single `_warn_wqx3_unavailable()` helper (alongside the existing `_warn_wqx3_use()` / `_warn_legacy_use()` helpers) so callers can filter, redirect, or capture them via `warnings`/`pytest.warns`. Also collapses the redundant `if legacy is True: url = X else: warn(); url = X` branches (both arms assigned the same legacy URL). The new `_legacy_only_url` helper additionally suppresses the legacy `DeprecationWarning` that `wqp_url` would otherwise raise — its message claims setting `legacy=False` removes it, which is a lie for endpoints that have no WQX3.0 alternative.
- **Fix exception shape in `wqp_url` / `wqx3_url`**: `TypeError("... Valid options are", f"{services}.")` produced an exception whose `args` is a 2-tuple of strings, breaking the message rendering and using the wrong exception class (`ValueError` is the right type for an unrecognized argument value). Replaced with a single `ValueError` carrying one f-string.
- **Consistency**: `what_activity_metrics` was the only `read_csv` site in this module without `low_memory=False`. Added it for parity with the other eight helpers.
- **Typos**: `Retrun` -> `Return` (docstring); `intermitttently` -> `intermittently` (warning text).

## Test plan
- [x] Existing 12 wqp tests still pass. (No new tests — each fix here is small enough that the diff is self-documenting and a regression would be loud at the API surface.)

## Related PRs

Other open PRs in this bug-review series that touch `dataretrieval/wqp.py` (different functions, no functional conflicts):
- **#249** — fix `WQP_Metadata.site_info` property binding.
- **#250** — preserve user-supplied WQX3.0 `dataProfile` in `get_results`. An earlier draft of this PR also touched `get_results`'s `TypeError` -> `ValueError` shape; that overlap was reverted so #250 fully owns the `get_results` rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)