### PR TITLE
Make _handle_stats_nesting tolerant of missing drop columns

### DIFF
--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -892,11 +892,13 @@ def _handle_stats_nesting(
     # otherwise return a geodataframe
     if not geopd:
         df = pd.json_normalize(body["features"]).drop(
-            columns=["type", "properties.data"]
+            columns=["type", "properties.data"], errors="ignore"
         )
         df.columns = df.columns.str.split(".").str[-1]
     else:
-        df = gpd.GeoDataFrame.from_features(body["features"]).drop(columns=["data"])
+        df = gpd.GeoDataFrame.from_features(body["features"]).drop(
+            columns=["data"], errors="ignore"
+        )
 
     # Unnest json features, properties, data, and values while retaining necessary
     # metadata to merge with main dataframe.

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -4,6 +4,7 @@ import requests
 
 from dataretrieval.waterdata.utils import (
     _get_args,
+    _handle_stats_nesting,
     _walk_pages,
 )
 
@@ -80,3 +81,33 @@ def test_walk_pages_multiple_mocked():
     assert mock_client.send.called
     assert mock_client.request.called
     assert mock_client.request.call_args[0][1] == "https://example.com/page2"
+
+
+def test_handle_stats_nesting_tolerates_missing_drop_columns():
+    """If the upstream stats response shape ever changes such that one of
+    the columns we try to drop ("type", "properties.data") is absent, the
+    function should still return a DataFrame instead of raising KeyError.
+    """
+    body = {
+        "next": None,
+        "features": [
+            {
+                "properties": {
+                    "monitoring_location_id": "USGS-12345",
+                    "data": [
+                        {
+                            "parameter_code": "00060",
+                            "unit_of_measure": "ft^3/s",
+                            "parent_time_series_id": "ts-1",
+                            "values": [{"statistic_id": "mean", "value": 10.0}],
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+    df = _handle_stats_nesting(body, geopd=False)
+
+    assert len(df) == 1
+    assert df["monitoring_location_id"].iloc[0] == "USGS-12345"


### PR DESCRIPTION
## Summary

`_handle_stats_nesting` has two `.drop(columns=...)` calls (one for the geopandas branch, one for the pandas branch) that hardcode literal column names — `[\"type\", \"properties.data\"]` and `[\"data\"]` respectively. If a stats response ever comes back in a slightly different shape (renamed key, missing optional key, edge-case feature without the expected nesting), `drop()` raises `KeyError` and aborts the helper.

The sibling `pd.json_normalize(...)` call later in the same function already passes `errors=\"ignore\"`, so this PR adds the same to the two `drop()` calls for parity.

## Diff

```python
# dataretrieval/waterdata/utils.py:894-901
if not geopd:
    df = pd.json_normalize(body[\"features\"]).drop(
        columns=[\"type\", \"properties.data\"], errors=\"ignore\"  # <-- added
    )
    df.columns = df.columns.str.split(\".\").str[-1]
else:
    df = gpd.GeoDataFrame.from_features(body[\"features\"]).drop(
        columns=[\"data\"], errors=\"ignore\"  # <-- added
    )
```

## Test plan
- [x] New test `test_handle_stats_nesting_tolerates_missing_drop_columns` constructs a stats body whose features lack the top-level `type` key and confirms the function returns a populated DataFrame.
- [x] Verified that the new test fails on `main` with `KeyError: \"['type'] not found in axis\"`.
- [x] Full waterdata_utils test suite passes (5 tests).
- [x] Full test suite (excluding deprecated `nwis_test.py`): 197 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs

Other open PRs in this bug-review series that touch `dataretrieval/waterdata/utils.py` (different functions, no functional conflicts):
- **#247** — `_format_api_dates` accept ISO 8601.
- **#254** — `_arrange_cols` stop mutating caller list.
- **#255** — stats / OGC pagination tighten.
- **#257** — `_handle_stats_nesting` tolerate missing drop columns.