### PR TITLE
nldi: raise ValueError (not TypeError) for invalid navigation mode

### DIFF
--- a/dataretrieval/nldi.py
+++ b/dataretrieval/nldi.py
@@ -486,7 +486,7 @@ def _validate_data_source(data_source: str):
 def _validate_navigation_mode(navigation_mode: str):
     navigation_mode = navigation_mode.upper()
     if navigation_mode not in ("UM", "DM", "UT", "DD"):
-        raise TypeError(f"Invalid navigation mode '{navigation_mode}'")
+        raise ValueError(f"Invalid navigation mode '{navigation_mode}'")
 
 
 def _validate_feature_source_comid(

--- a/tests/nldi_test.py
+++ b/tests/nldi_test.py
@@ -1,9 +1,7 @@
-import pytest
 from geopandas import GeoDataFrame
 
 from dataretrieval.nldi import (
     NLDI_API_BASE_URL,
-    _validate_navigation_mode,
     get_basin,
     get_features,
     get_flowlines,
@@ -282,9 +280,3 @@ def test_search_for_features_by_lat_long(requests_mock):
     assert search_results["features"][0]["type"] == "Feature"
     assert search_results["features"][0]["geometry"]["type"] == "LineString"
     assert len(search_results["features"][0]["geometry"]["coordinates"]) == 27
-
-
-def test_validate_navigation_mode_invalid_raises_value_error():
-    """Invalid navigation mode is a bad value, not a bad type -> ValueError."""
-    with pytest.raises(ValueError, match="Invalid navigation mode"):
-        _validate_navigation_mode("XX")

--- a/tests/nldi_test.py
+++ b/tests/nldi_test.py
@@ -1,7 +1,9 @@
+import pytest
 from geopandas import GeoDataFrame
 
 from dataretrieval.nldi import (
     NLDI_API_BASE_URL,
+    _validate_navigation_mode,
     get_basin,
     get_features,
     get_flowlines,
@@ -280,3 +282,9 @@ def test_search_for_features_by_lat_long(requests_mock):
     assert search_results["features"][0]["type"] == "Feature"
     assert search_results["features"][0]["geometry"]["type"] == "LineString"
     assert len(search_results["features"][0]["geometry"]["coordinates"]) == 27
+
+
+def test_validate_navigation_mode_invalid_raises_value_error():
+    """Invalid navigation mode is a bad value, not a bad type -> ValueError."""
+    with pytest.raises(ValueError, match="Invalid navigation mode"):
+        _validate_navigation_mode("XX")


### PR DESCRIPTION
## Summary

`_validate_navigation_mode` raises `TypeError` for an invalid string value (e.g., `"XX"`). The sister helper `_validate_data_source` in the same file already raises `ValueError` for the same kind of bad-input case. `TypeError` is reserved for cases where an arguments *type* is wrong; an unrecognized navigation-mode string is a *value* error, so callers writing `except ValueError:` would not catch it today.

```python
# dataretrieval/nldi.py:486-489
def _validate_navigation_mode(navigation_mode: str):
    navigation_mode = navigation_mode.upper()
    if navigation_mode not in ("UM", "DM", "UT", "DD"):
        raise ValueError(f"Invalid navigation mode '{navigation_mode}'")  # was TypeError
```

One-line change; no regression test (the assertion would just re-state the diff).

## Related PRs

This is a **strict subset of #252** (`nldi-cleanup`), which also changes `TypeError` -> `ValueError` here as part of a larger refactor (extracts `_VALID_NAVIGATION_MODES`, normalizes input and returns it, adds a `None` guard). If #252 lands first, this PR can be closed.

#246 (`nldi-data-source-validation`) also touches `nldi.py` but a different function (`_validate_data_source`); no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)