### PR TITLE
Skip NADP live-API tests (module deprecated)

### DIFF
--- a/tests/nadp_test.py
+++ b/tests/nadp_test.py
@@ -2,7 +2,14 @@
 
 import os
 
+import pytest
+
 from dataretrieval import nadp
+
+pytestmark = pytest.mark.skip(
+    reason="NADP module deprecated; removal scheduled 2026-11-01. "
+    "Tests hit live NADP services and were causing CI flakes."
+)
 
 
 class TestMDNmap:


### PR DESCRIPTION
## Summary
- The NADP module is deprecated with a removal date of 2026-11-01 (#243).
- Both tests in `tests/nadp_test.py` hit the live NADP services and have been intermittently exhausting CI retries.
- Apply a module-level `pytestmark = pytest.mark.skip(...)` so they're disabled but the bodies stay around during the deprecation window. Once the module is removed the test file can go with it.

## Test plan
- [x] `pytest tests/nadp_test.py` reports `2 skipped`.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)