### PR TITLE
Enrich waterdata getter docstrings with examples adapted from R

### DIFF
--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -208,11 +208,27 @@ def get_daily(
         ...     time="2021-01-01T00:00:00Z/2022-01-01T00:00:00Z",
         ... )
 
+        >>> # Quick "show me the last week" idiom (ISO 8601 duration)
+        >>> df, md = dataretrieval.waterdata.get_daily(
+        ...     monitoring_location_id="USGS-02238500",
+        ...     parameter_code="00060",
+        ...     time="P7D",
+        ... )
+
         >>> # Get approved daily flow data from multiple sites
         >>> df, md = dataretrieval.waterdata.get_daily(
-        ...     monitoring_location_id = ["USGS-05114000", "USGS-09423350"],
-        ...     approval_status = "Approved",
-        ...     time = "2024-01-01/.."
+        ...     monitoring_location_id=["USGS-05114000", "USGS-09423350"],
+        ...     approval_status="Approved",
+        ...     time="2024-01-01/..",
+        ... )
+
+        >>> # Pull only rows whose underlying record was refreshed in the
+        >>> # last 7 days — handy for incremental ETL polling
+        >>> df, md = dataretrieval.waterdata.get_daily(
+        ...     monitoring_location_id="USGS-02238500",
+        ...     parameter_code="00060",
+        ...     last_modified="P7D",
+        ... )
     """
     service = "daily"
     output_id = "daily_id"
@@ -1097,6 +1113,22 @@ def get_latest_continuous(
         ...     monitoring_location_id="USGS-02238500", parameter_code="00060"
         ... )
 
+        >>> # Restrict to the last 7 days; sites with no observation in that
+        >>> # window are dropped instead of returned with stale values
+        >>> df, md = dataretrieval.waterdata.get_latest_continuous(
+        ...     monitoring_location_id="USGS-02238500",
+        ...     parameter_code="00060",
+        ...     time="P7D",
+        ... )
+
+        >>> # Pull only rows whose underlying record was refreshed in the
+        >>> # last 7 days, across multiple sites and parameters
+        >>> df, md = dataretrieval.waterdata.get_latest_continuous(
+        ...     monitoring_location_id=["USGS-451605097071701", "USGS-14181500"],
+        ...     parameter_code=["00060", "72019"],
+        ...     last_modified="P7D",
+        ... )
+
         >>> # Get latest continuous measurements for multiple sites
         >>> df, md = dataretrieval.waterdata.get_latest_continuous(
         ...     monitoring_location_id=["USGS-05114000", "USGS-09423350"]
@@ -1278,6 +1310,21 @@ def get_latest_daily(
         ...     monitoring_location_id="USGS-02238500", parameter_code="00060"
         ... )
 
+        >>> # Restrict to rows whose underlying record was refreshed in the
+        >>> # last 7 days
+        >>> df, md = dataretrieval.waterdata.get_latest_daily(
+        ...     monitoring_location_id="USGS-02238500",
+        ...     parameter_code="00060",
+        ...     last_modified="P7D",
+        ... )
+
+        >>> # Multi-site, multi-parameter — discharge and water temperature
+        >>> # at two sites in a single round-trip
+        >>> df, md = dataretrieval.waterdata.get_latest_daily(
+        ...     monitoring_location_id=["USGS-01491000", "USGS-01645000"],
+        ...     parameter_code=["00060", "00010"],
+        ... )
+
         >>> # Get most recent daily measurements for two sites
         >>> df, md = dataretrieval.waterdata.get_latest_daily(
         ...     monitoring_location_id=["USGS-05114000", "USGS-09423350"]
@@ -1452,6 +1499,14 @@ def get_field_measurements(
         ...     monitoring_location_id="USGS-375907091432201",
         ...     parameter_code="72019",
         ...     skip_geometry=True,
+        ... )
+
+        >>> # Half-bounded time range: every measurement at this site since
+        >>> # 1980 (open-ended end). Use ``"../<date>"`` for the inverse
+        >>> # (everything up to a date).
+        >>> df, md = dataretrieval.waterdata.get_field_measurements(
+        ...     monitoring_location_id="USGS-425957088141001",
+        ...     time="1980-01-01/..",
         ... )
 
         >>> # Get field measurements from multiple sites and

--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -1512,10 +1512,12 @@ def get_field_measurements(
         >>> # Get field measurements from multiple sites and
         >>> # parameter codes from the last 20 years
         >>> df, md = dataretrieval.waterdata.get_field_measurements(
-        ...     monitoring_location_id = ["USGS-451605097071701",
-                                          "USGS-263819081585801"],
-        ...     parameter_code = ["62611", "72019"],
-        ...     time = "P20Y"
+        ...     monitoring_location_id=[
+        ...         "USGS-451605097071701",
+        ...         "USGS-263819081585801",
+        ...     ],
+        ...     parameter_code=["62611", "72019"],
+        ...     time="P20Y",
         ... )
     """
     service = "field-measurements"


### PR DESCRIPTION
## Summary

Cross-referenced each Python `waterdata` getter's Examples section against the corresponding R analogue in [DOI-USGS/dataRetrieval](https://github.com/DOI-USGS/dataRetrieval/tree/develop/R) and ported the distinctive examples that the Python docs were missing. Same rationale as the audit done for `get_combined_metadata` in #264 — many R example sets cover useful idioms (ISO 8601 durations, half-bounded time intervals, `last_modified` for incremental polling, multi-value POST queries) that aren't yet shown in the Python docs.

Docs only — no signature, behavior, or test changes.

## Functions touched and what was added

| Function | Added |
| --- | --- |
| `get_daily` | ISO 8601 duration (`time="P7D"`) example; `last_modified="P7D"` example for incremental ETL polling. **Also fixed** a pre-existing bug where the multi-site / `approval_status` example block was missing its closing parenthesis and trailing comma. |
| `get_latest_continuous` | `time="P7D"` example (drops sites with no recent observation); multi-site / multi-parameter + `last_modified="P7D"` example. |
| `get_latest_daily` | `last_modified="P7D"` example; multi-site + multi-parameter (discharge + water-temperature) example. |
| `get_field_measurements` | Half-bounded time example (`"1980-01-01/.."` for everything since 1980; documents the inverse `"../<date>"` form). |

## What was deliberately skipped

- Functions whose example coverage already matched or exceeded R's: `get_continuous` (5 examples), `get_monitoring_locations` (2 well-chosen ones already, R's bbox+chaining cases would duplicate `get_combined_metadata`'s new chaining example in #264), `get_time_series_metadata`, `get_stats_por`, `get_stats_date_range`, `get_samples`, `get_codes`, `get_reference_table`, `get_channel`, `get_samples_summary`.
- R-only kwargs that have no Python equivalent (`no_paging`, `attach_request`, `chunk_size`, `convertType` flag toggling). Filter chunking happens automatically in Python.
- `get_daily`'s R `dv_post` example using `approval_status=c("Approved", "Provisional")` — Python already has an `approval_status="Approved"` example.

## Test plan

- [x] `ruff check` clean.
- [x] Each function's `__doc__` renders correctly (verified via `help()`).
- [ ] **Live API spot-check**: attempted but blocked by a 429 rate limit. The new examples only exercise date-format and multi-value idioms (`P7D` duration, `1980-01-01/..` half-bounded interval, `last_modified` field) that are already covered by existing tests and other functions' working examples.

## Related
- #264 (added `get_combined_metadata` with the same docs philosophy applied to a single new function).