### PR TITLE
Fix missing comma in get_reference_table doctest example

### DIFF
--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -2050,8 +2050,8 @@ def get_reference_table(
 
         >>> # Get table of selected USGS parameter codes
         >>> ref, md = dataretrieval.waterdata.get_reference_table(
-        ...     collection="parameter-codes"
-        ...     query={'id': '00001,00002'}
+        ...     collection="parameter-codes",
+        ...     query={"id": "00001,00002"},
         ... )
     """
     valid_code_services = get_args(METADATA_COLLECTIONS)


### PR DESCRIPTION
The second example block in `get_reference_table`'s docstring is unrunnable — `collection="parameter-codes"` and `query={...}` are on separate lines with no comma between them, so the doctest text would not parse as a valid Python call.

## Before (broken)

\`\`\`python
>>> ref, md = dataretrieval.waterdata.get_reference_table(
...     collection="parameter-codes"
...     query={'id': '00001,00002'}
... )
\`\`\`

## After

\`\`\`python
>>> ref, md = dataretrieval.waterdata.get_reference_table(
...     collection="parameter-codes",
...     query={"id": "00001,00002"},
... )
\`\`\`

(Single quotes inside the dict are normalized to double quotes to match the rest of the file's style — drive-by, no functional change.)

## Why

Surfaced while running each public-function docstring example against the live USGS OGC API as part of PR #229's verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)