### PR TITLE
perf(waterdata): compact CQL2 JSON to halve POST chunk count

### DIFF
--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -316,7 +316,17 @@ def _cql2_param(args: dict[str, Any]) -> str:
     Returns
     -------
     str
-        JSON string representation of the CQL2 query.
+        Compact JSON string representation of the CQL2 query.
+
+    Notes
+    -----
+    Serialized with the tightest separators (no indentation or
+    whitespace). The body counts against the server's ~8 KB request-size
+    limit and against :func:`chunking._request_bytes` when planning
+    chunks, so every saved byte fits more values per POST: compact
+    encoding roughly halves the per-value cost versus pretty-printing,
+    which roughly doubles how many monitoring-location ids fit in one
+    sub-request and so halves the chunk count for large id lists.
     """
     filters = []
     for key, values in args.items():
@@ -324,7 +334,7 @@ def _cql2_param(args: dict[str, Any]) -> str:
 
     query = {"op": "and", "args": filters}
 
-    return json.dumps(query, indent=4)
+    return json.dumps(query, separators=(",", ":"))
 
 
 def _default_headers():

--- a/tests/waterdata_test.py
+++ b/tests/waterdata_test.py
@@ -157,6 +157,13 @@ def test_construct_api_requests_monitoring_locations_post():
     assert req.method == "POST"
     assert req.headers["Content-Type"] == "application/query-cql-json"
 
+    # Body is serialized compactly (tight separators, no whitespace): the
+    # body counts against the server's ~8 KB request-size cap and the
+    # chunk planner's byte budget, so pretty-printing would needlessly
+    # halve how many ids fit per sub-request and double the chunk count.
+    raw = req.content.decode()
+    assert "\n" not in raw and ", " not in raw and ": " not in raw
+
     body = json.loads(req.content)
     # Top-level shape: AND over a list of per-param predicates.
     assert body["op"] == "and"


### PR DESCRIPTION
## What
`monitoring-locations` is the one service that sends its multi-value filter as a CQL2 **POST body** (it doesn't accept comma-separated multi-value GET params). That body was pretty-printed with `json.dumps(..., indent=4)` (~39 bytes/value). The body counts against **both** the server's ~8 KB request-size limit **and** the chunk planner's byte budget (`chunking._request_bytes` = URL + body), so the indentation was doubling the per-value cost and therefore doubling the chunk count for large id lists.

This switches `_cql2_param` to the tightest separators, `json.dumps(..., separators=(",", ":"))` (~17 bytes/value).

## Impact
Sub-requests for a `monitoring-locations` id-list query at the production 8000-byte limit, via the real `ChunkPlan` planner:

| n_ids | indent=4 (old) | compact (new) | reduction |
|------:|---------------:|--------------:|-----------|
| 200   | 1  | 1  | — |
| 500   | 4  | 2  | 2× fewer |
| 1000  | 8  | 4  | 2× fewer |
| 2000  | 16 | 8  | 2× fewer |
| 5000  | 32 | 16 | 2× fewer |

## Verification
- **Compact body:** `{"op":"and","args":[{"op":"in","args":[{"property":"monitoring_location_id"},["USGS-05407000","USGS-05428500"]]}]}` — no whitespace.
- **Live:** a 2-id query returns the 2 correct sites; a 500-id query fans into 2 compact chunks and returns all 500 rows.
- Offline suite green; added a compactness assertion to the `monitoring-locations` POST test.

## Safety
Empirically pinned the server's request-size ceilings: GET URLs `414` above ~8.2–8.4 KB; POST bodies `403` above ~8.2–8.4 KB. The chunker's existing 8000-byte limit keeps compact bodies (≤ ~7.75 KB) safely under the 403 cutoff, so no limit change is needed.

## Note: why not route GET endpoints (`daily`, …) through POST?
Investigated and rejected. The server enforces the **same ~8 KB cap on total request size** whether the bytes are in the URL (`414`) or the body (`403`). A compact POST body fits ~450 sites; an 8000-byte GET URL fits ~450 sites — same capacity. So POST can't reduce the chunk count for the GET-based time-series endpoints; this compact win applies only to the pre-existing POST path. The real levers there (the ~8 KB edge limit and the 10,000-row page cap) are server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)