### PR TITLE
ci: pass API_USGS_PAT to docs + tests; cache Sphinx build outputs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,6 +47,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test,nldi]
       - name: Test with pytest and report coverage
+        env:
+          # The live-API portion of ``tests/waterdata_test.py`` benefits
+          # from the authenticated rate limit. Undefined
+          # ``secrets.API_USGS_PAT`` resolves to an empty string —
+          # falling back to unauthenticated, same as today.
+          API_USGS_PAT: ${{ secrets.API_USGS_PAT }}
         run: |
           coverage run -m pytest tests/
           coverage report -m

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -21,6 +21,15 @@ jobs:
           cache: "pip"
       - name: Install dataretrieval, dependencies, and Sphinx then build docs
         shell: bash -l {0}
+        env:
+          # nbsphinx executes every notebook with no committed outputs
+          # (the project convention; ``nbsphinx_execute`` defaults to
+          # ``'auto'``). Without an API key the doc build hits the
+          # unauthenticated rate limit (~60 req/min); the secret raises
+          # the ceiling so the build is reliable as the demo notebook set
+          # grows. Undefined ``secrets.API_USGS_PAT`` resolves to an
+          # empty string — falling back to unauthenticated, same as today.
+          API_USGS_PAT: ${{ secrets.API_USGS_PAT }}
         run: |
           python -m pip install --upgrade pip
           pip install .[doc,nldi]

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -19,6 +19,25 @@ jobs:
         with:
           python-version: "3.13"
           cache: "pip"
+
+      # Cache Sphinx's doctree + intermediate build outputs across CI runs,
+      # keyed on the hash of every source that affects the rendered docs
+      # (notebooks, RST/MD, conf.py, and the Python package — autodoc reads
+      # docstrings). Any source change invalidates the key, forcing a full
+      # rebuild; otherwise Sphinx skips re-parsing unchanged files, which
+      # for nbsphinx (``nbsphinx_execute='auto'``) means unchanged
+      # notebooks aren't re-executed. The HTML output is rebuilt against
+      # whatever doctrees we restore. (A proper jupyter-cache adoption via
+      # MyST-NB is the deeper migration path; this caches the equivalent
+      # via the build dir without the doc-tree rewrite.)
+      - name: Cache Sphinx build outputs
+        uses: actions/cache@v4
+        with:
+          path: docs/build
+          key: sphinx-${{ hashFiles('demos/**/*.ipynb', 'docs/source/**/*.rst', 'docs/source/**/*.md', 'docs/source/conf.py', 'dataretrieval/**/*.py') }}
+          restore-keys: |
+            sphinx-
+
       - name: Install dataretrieval, dependencies, and Sphinx then build docs
         shell: bash -l {0}
         env:


### PR DESCRIPTION
Two small CI improvements that compound. Targeted at the doc-build and live-test workflows that hit the live Water Data API.

## Commits

| | |
|---|---|
| `ci: pass API_USGS_PAT to docs + test workflows when the secret is set` | Adds `env: API_USGS_PAT: ${{ secrets.API_USGS_PAT }}` to the build step in `sphinx-docs.yml` and the pytest step in `python-package.yml`. |
| `ci(docs): cache Sphinx build outputs across runs` | Adds `actions/cache@v4` on `docs/build/` keyed on source hashes, so unchanged notebooks aren't re-executed on the next CI run. |

## What problem this solves

1. **The doc build runs every notebook live on every CI invocation.** The project convention is no committed notebook outputs (verified on `main` — all `.ipynb` ship with empty `outputs` arrays), so `nbsphinx`'s default `'auto'` mode executes every notebook against the live API on every `push` and `pull_request`.
2. **Currently unauthenticated.** No workflow references `API_USGS_PAT` today, so the doc build (and the live tests in `python-package.yml`) hit the ~60 req/min unauthenticated rate limit. As the demo notebook set grows this becomes increasingly fragile.

## What this PR does

### Commit 1 — pass through `API_USGS_PAT`
The change is purely additive: if `secrets.API_USGS_PAT` is configured (in repo settings), both workflows pick up the authenticated quota. If it isn't, the env var resolves to an empty string and the workflows fall back to today's unauthenticated behavior — **no observable change until the secret is added**.

> **Maintainer action required:** add `API_USGS_PAT` as an Actions secret in repo settings to actually pick up the higher rate limit. The PR is no-op until then.

### Commit 2 — cache Sphinx build outputs
`actions/cache@v4` persists `docs/build/` (which includes `.doctrees/`) across CI runs. Sphinx checks source mtimes against the doctree; unchanged sources skip re-parsing, which for `nbsphinx` (`nbsphinx_execute='auto'`) means **unchanged notebooks aren't re-executed**. The cache key hashes every input that affects the rendered docs — notebooks, RST/MD, `conf.py`, and the Python package (autodoc reads docstrings) — so any source change invalidates exact-match. The `restore-keys: sphinx-` fallback gives partial-match recovery: even a key miss restores recent doctrees, and Sphinx then only re-builds the files whose source actually changed.

Result: most PRs only touch a handful of files, so the doc build re-executes only the actually-changed notebooks instead of the whole 19-notebook set.

## What this PR does NOT do (intentional)

- **Doesn't switch to `MyST-NB` + `jupyter-cache`.** That's the canonical "adopt jupyter-cache" path (`nb_execution_mode = 'cache'` integrates jupyter-cache natively), but it requires reworking the existing `.nblink` references to external notebooks under `demos/`. Caching `docs/build/` via `actions/cache` achieves the equivalent functional benefit without the doc-tree rewrite. The MyST-NB migration is a worthwhile larger follow-up.
- **Doesn't add the `API_USGS_PAT` secret** (can't be done from code; that's a repo-settings action).
- **Doesn't change any notebook or doc content.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)