### PR TITLE
docs: fix WQP README example unpacking and stale install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Access water quality data from multiple agencies:
 ```python
 from dataretrieval import wqp
 
-# Find water quality monitoring sites
-sites = wqp.what_sites(
+# Find water quality monitoring sites (returns a DataFrame and metadata)
+sites, metadata = wqp.what_sites(
     statecode='US:55',  # Wisconsin
     siteType='Stream'
 )
@@ -134,7 +134,7 @@ sites = wqp.what_sites(
 print(f"Found {len(sites)} stream monitoring sites in Wisconsin")
 
 # Get water quality results
-results = wqp.get_results(
+results, metadata = wqp.get_results(
     siteid='USGS-05427718',
     characteristicName='Temperature, water'
 )

--- a/docs/source/meta/installing.rst
+++ b/docs/source/meta/installing.rst
@@ -3,13 +3,9 @@ Installation Guide
 
 Whether you are a user or developer we recommend installing ``dataretrieval``
 in a virtual environment. This can be done using something like ``virtualenv``
-or ``conda``. Package dependencies are listed in the `requirements.txt`_ file,
-a full list of dependencies necessary for development are listed in the
-`requirements-dev.txt`_ file.
-
-.. _requirements.txt: https://github.com/DOI-USGS/dataretrieval-python/blob/main/requirements.txt
-
-.. _requirements-dev.txt: https://github.com/DOI-USGS/dataretrieval-python/blob/main/requirements-dev.txt
+or ``conda``. Package dependencies are declared in ``pyproject.toml``: the core
+runtime dependencies under ``[project.dependencies]``, and optional extras
+(``test``, ``doc``, ``nldi``) under ``[project.optional-dependencies]``.
 
 
 User Installation
@@ -59,8 +55,11 @@ the package for development:
 
 .. code-block:: bash
 
-    $ pip install -r requirements-dev.txt
-    $ pip install -e .
+    $ pip install -e ".[test,doc,nldi]"
+
+This installs ``dataretrieval`` in editable mode along with the development
+extras: ``test`` (test runner), ``doc`` (documentation build), and ``nldi``
+(``geopandas``, required by the NLDI module).
 
 To check your installation you can run the tests with the following commands:
 


### PR DESCRIPTION
## Summary

Two documentation fixes for copy-paste-broken examples, each verified against the live API / repo. Docs only — no code changes.

## README — WQP examples discarded the metadata tuple

`wqp.what_sites(...)` and `wqp.get_results(...)` return `(DataFrame, WQP_Metadata)`, but the examples assigned the whole tuple to `sites` / `results`, so `len(sites)` / `len(results)` always printed `2` (the tuple length), not the row count.

**Fix:** unpack `sites, metadata = ...` / `results, metadata = ...` (matching the Water Data examples above). Verified live — the corrected snippet prints `Found 25573 stream monitoring sites in Wisconsin` and `Retrieved 163 temperature measurements`.

## `docs/source/meta/installing.rst` — referenced removed `requirements*.txt`

Dependencies moved to `pyproject.toml`, but the install guide still pointed at `requirements.txt` / `requirements-dev.txt` (which don't exist) and instructed `pip install -r requirements-dev.txt`.

**Fix:** the intro now points at `pyproject.toml` (`[project.dependencies]` + `[project.optional-dependencies]`); the developer install becomes `pip install -e ".[test,doc,nldi]"` (extras confirmed present in `pyproject.toml`); removed the two dangling rst link targets.

## NLDI examples — checked and intentionally left unchanged

A review had flagged the README's `nldi.get_basin(feature_source='comid', ...)` / `get_flowlines(feature_source='comid', ...)` as broken. Checked against the **live** NLDI API: `comid` is a valid source and both calls return data (`get_basin` → 1 feature, `get_flowlines` → 7 flowlines). No change made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
