### PR TITLE
docs(waterdata): drop R-analogue notes from getter docstrings

### DIFF
--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -1047,8 +1047,6 @@ def get_combined_metadata(
 
     See the OpenAPI reference for the full list of supported fields:
     https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=html#/combined-metadata
-    The R analogue is ``read_waterdata_combined_meta`` in
-    https://github.com/DOI-USGS/dataRetrieval/.
 
     All ~35 location-catalog kwargs are accepted (``agency_code``,
     ``state_name``, ``drainage_area``, ``aquifer_code``, …) but only
@@ -1813,8 +1811,6 @@ def get_field_measurements_metadata(
 
     See the OpenAPI reference for the full list of supported fields:
     https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=html#/field-measurements-metadata
-    The R analogue is ``read_waterdata_field_meta`` in
-    https://github.com/DOI-USGS/dataRetrieval/.
 
     Parameters
     ----------

--- a/dataretrieval/waterdata/ratings.py
+++ b/dataretrieval/waterdata/ratings.py
@@ -5,9 +5,6 @@ RDB downloads that follow. The STAC endpoint hosts standard NWIS rating
 files (``exsa``, ``base``, ``corr``) for active streamgages — see the
 service overview at https://api.waterdata.usgs.gov/docs/stac/ and the
 WDFN announcement at https://waterdata.usgs.gov/blog/wdfn-rating-curves/.
-
-The R analogue is ``read_waterdata_ratings`` in
-https://github.com/DOI-USGS/dataRetrieval/.
 """
 
 from __future__ import annotations
@@ -65,8 +62,7 @@ def get_ratings(
 
     See https://api.waterdata.usgs.gov/docs/stac/ for the upstream service
     docs and https://waterdata.usgs.gov/blog/wdfn-rating-curves/ for the
-    background announcement. The R analogue is ``read_waterdata_ratings``
-    in https://github.com/DOI-USGS/dataRetrieval/.
+    background announcement.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary

Removes the "The R analogue is `read_waterdata_…`" notes from three Water Data getter docstrings and the `ratings` module docstring:

- `get_combined_metadata`
- `get_field_measurements_metadata`
- `get_ratings` (and the `ratings.py` module docstring)

These cross-package pointers to R `dataRetrieval` don't help a Python caller reading `help(...)`, and the other getters (`get_daily`, `get_continuous`, `get_waterdata`, …) don't carry them — so this makes the docstrings consistent and lets each describe the function on its own terms.

Kept intentionally:
- the OpenAPI / STAC / WDFN service-reference links, and
- the Python-to-Python cross-reference in `get_field_measurements_metadata` ("the discrete-measurement analogue to `get_time_series_metadata`"), which points at a related function in this package.

Docstrings only — no code or signature changes. `ruff` clean; imports verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
