### PR TITLE
fix(nwis): stop emitting a DeprecationWarning at import time

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -24,14 +24,6 @@ try:
 except ImportError:
     gpd = None
 
-# Issue deprecation warning upon import
-warnings.warn(
-    "The 'nwis' services are deprecated and being decommissioned. "
-    "Please use the 'waterdata' module to access the new services.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
 WATERDATA_BASE_URL = "https://nwis.waterdata.usgs.gov/"
 WATERDATA_URL = WATERDATA_BASE_URL + "nwis/"
 WATERSERVICE_URL = "https://waterservices.usgs.gov/nwis/"


### PR DESCRIPTION
## Problem

`dataretrieval/nwis.py` issues a `DeprecationWarning` at **module top-level**, and `dataretrieval/__init__.py` does `from dataretrieval.nwis import *` unconditionally. So **`import dataretrieval` emits a `DeprecationWarning`** for every consumer — even users who only touch the `waterdata` module — and **fails to import at all under `-W error::DeprecationWarning`** (a common CI configuration):

```
$ python -W error::DeprecationWarning -c "import dataretrieval"
DeprecationWarning: The 'nwis' services are deprecated and being decommissioned. ...
```

## Fix

Remove the module-level warning. Deprecation is already signaled where it's actionable: the `@_deprecated` decorator wraps every public nwis function and emits a per-function `DeprecationWarning` on use (with a thread-local guard so layered wrappers warn once). That targeted mechanism is unchanged.

## Verification

- `python -W error::DeprecationWarning -c "import dataretrieval"` now succeeds.
- Calling a deprecated function still warns: `nwis.get_record(...)` →
  `` `nwis.get_record` is deprecated and will be removed ... use the appropriate `waterdata.get_*()` ... ``
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
