### PR TITLE
fix(waterdata)!: return (df, BaseMetadata) from get_codes

### DIFF
--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -2100,7 +2100,7 @@ def get_reference_table(
     )
 
 
-def get_codes(code_service: CODE_SERVICES) -> pd.DataFrame:
+def get_codes(code_service: CODE_SERVICES) -> tuple[pd.DataFrame, BaseMetadata]:
     """Return codes from a Samples code service.
 
     Parameters
@@ -2109,6 +2109,13 @@ def get_codes(code_service: CODE_SERVICES) -> pd.DataFrame:
         One of the following options: "states", "counties", "countries"
         "sitetype", "samplemedia", "characteristicgroup", "characteristics",
         or "observedproperty"
+
+    Returns
+    -------
+    df : ``pandas.DataFrame``
+        The requested code table.
+    md : :obj:`dataretrieval.utils.BaseMetadata`
+        Metadata for the query (URL, query time, response headers).
     """
     valid_code_services = get_args(CODE_SERVICES)
     if code_service not in valid_code_services:
@@ -2128,7 +2135,7 @@ def get_codes(code_service: CODE_SERVICES) -> pd.DataFrame:
 
     df = pd.DataFrame(data_list)
 
-    return df
+    return df, BaseMetadata(response)
 
 
 def _get_samples_csv(


### PR DESCRIPTION
## Problem

`get_codes` is the **only** public `waterdata` getter that returns a bare `DataFrame` instead of the module-wide `(DataFrame, BaseMetadata)` tuple. So the universal idiom every other getter supports —

```python
df, md = waterdata.get_codes("samplemedia")   # ValueError: too many values to unpack
```

— breaks, even though `get_codes` already builds `response` and calls `_raise_for_non_200(response)` (the metadata is in hand, just discarded).

## Fix

Return `(df, BaseMetadata(response))`, matching `get_reference_table` and every other getter.

> ⚠️ **Breaking change.** Existing callers doing `df = get_codes(...)` must switch to `df, _ = get_codes(...)`. Opened as a draft so maintainers can decide whether to take the break now or stage a deprecation. `get_codes` is a relatively new `waterdata` addition, so the blast radius should be small.

## Verification (live API)

```python
df, md = waterdata.get_codes("samplemedia")
# is 2-tuple: True · df non-empty: True · md.url set: True · md.query_time present: True
```
`ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
