### PR TITLE
fix(nldi): return an empty GeoDataFrame instead of crashing on empty results

### DIFF
--- a/dataretrieval/nldi.py
+++ b/dataretrieval/nldi.py
@@ -32,6 +32,21 @@ def _query_nldi(url, query_params, error_message):
     return response_data
 
 
+def _features_to_gdf(feature_collection: dict) -> gpd.GeoDataFrame:
+    """Build a GeoDataFrame from an NLDI FeatureCollection, tolerating empties.
+
+    NLDI can legitimately return no features (e.g. a feature with nothing
+    upstream), and :func:`_query_nldi` returns ``{}`` when a 200 response
+    carries no JSON body. ``GeoDataFrame.from_features`` raises on those
+    (there's no geometry column to attach the CRS to), so return an empty
+    GeoDataFrame with the correct CRS instead of crashing.
+    """
+    features = feature_collection.get("features") if feature_collection else None
+    if not features:
+        return gpd.GeoDataFrame(geometry=[], crs=_CRS)
+    return gpd.GeoDataFrame.from_features(feature_collection, crs=_CRS)
+
+
 def get_flowlines(
     navigation_mode: str,
     distance: int = 5,
@@ -104,7 +119,7 @@ def get_flowlines(
     feature_collection = _query_nldi(url, query_params, err_msg)
     if as_json:
         return feature_collection
-    gdf = gpd.GeoDataFrame.from_features(feature_collection, crs=_CRS)
+    gdf = _features_to_gdf(feature_collection)
     return gdf
 
 
@@ -157,7 +172,7 @@ def get_basin(
     feature_collection = _query_nldi(url, query_params, err_msg)
     if as_json:
         return feature_collection
-    gdf = gpd.GeoDataFrame.from_features(feature_collection, crs=_CRS)
+    gdf = _features_to_gdf(feature_collection)
     return gdf
 
 
@@ -273,7 +288,7 @@ def get_features(
     feature_collection = _query_nldi(url, query_params, err_msg)
     if as_json:
         return feature_collection
-    gdf = gpd.GeoDataFrame.from_features(feature_collection, crs=_CRS)
+    gdf = _features_to_gdf(feature_collection)
     return gdf
 
 
@@ -307,7 +322,7 @@ def get_features_by_data_source(data_source: str) -> gpd.GeoDataFrame:
     url = f"{NLDI_API_BASE_URL}/{data_source}"
     err_msg = f"Error getting features for data source '{data_source}'"
     feature_collection = _query_nldi(url, {}, err_msg)
-    gdf = gpd.GeoDataFrame.from_features(feature_collection, crs=_CRS)
+    gdf = _features_to_gdf(feature_collection)
     return gdf
 
 


### PR DESCRIPTION
## Problem

NLDI can legitimately return **no features** (e.g. a feature with nothing upstream of it), and `_query_nldi` returns `{}` when a 200 response carries no JSON body (its own comment notes this happens). The four getters then call:

```python
gdf = gpd.GeoDataFrame.from_features(feature_collection, crs=_CRS)
```

which raises an opaque `ValueError: Assigning CRS to a GeoDataFrame without a geometry column is not supported` on a perfectly valid empty result. (`as_json=True` already tolerated empties; only the default GeoDataFrame path crashed.)

## Fix

Add a shared `_features_to_gdf` helper used by all four getters (`get_flowlines`, `get_basin`, `get_features`, `get_features_by_data_source`) that returns an empty `GeoDataFrame(geometry=[], crs=_CRS)` when there are no features, and otherwise behaves exactly as before.

## Verification

- **Local** (both crashing inputs confirmed pre-fix): `_features_to_gdf({})` and `_features_to_gdf({"features": []})` → empty GeoDataFrame (0 rows, `EPSG:4326`), no crash; a populated FeatureCollection → 1-row gdf with a geometry column.
- **Live API** (happy path unbroken): `get_flowlines(navigation_mode="UM", feature_source="nwissite", feature_id="USGS-01031500", distance=10)` → 7-row GeoDataFrame with geometry, `EPSG:4326`.
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
