### PR TITLE
fix(wqp): repair WQP_Metadata.site_info (was always None)

### DIFF
--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -155,7 +155,7 @@ def get_results(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
     df = _attach_datetime_columns(df)
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_sites(
@@ -210,7 +210,7 @@ def what_sites(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_organizations(
@@ -261,7 +261,7 @@ def what_organizations(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_projects(ssl_check=True, legacy=True, **kwargs):
@@ -308,7 +308,7 @@ def what_projects(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_activities(
@@ -372,7 +372,7 @@ def what_activities(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_detection_limits(
@@ -430,7 +430,7 @@ def what_detection_limits(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_habitat_metrics(
@@ -481,7 +481,7 @@ def what_habitat_metrics(
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_project_weights(ssl_check=True, legacy=True, **kwargs):
@@ -533,7 +533,7 @@ def what_project_weights(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
@@ -585,7 +585,7 @@ def what_activity_metrics(ssl_check=True, legacy=True, **kwargs):
 
     df = pd.read_csv(StringIO(response.text), delimiter=",", low_memory=False)
 
-    return df, WQP_Metadata(response)
+    return df, WQP_Metadata(response, **kwargs)
 
 
 def wqp_url(service):
@@ -627,10 +627,10 @@ class WQP_Metadata(BaseMetadata):
         Response elapsed time
     header : httpx.Headers
         Response headers
-    comments : None
-        Metadata comments. WQP does not return comments.
-    site_info : tuple[pd.DataFrame, NWIS_Metadata] | None
-        Site information if the query included `sites`, `site` or `site_no`.
+    comment : None
+        WQP does not return comments.
+    site_info : tuple[pd.DataFrame, WQP_Metadata] | None
+        Site information (via ``what_sites``) if the query included a ``siteid``.
     """
 
     def __init__(self, response, **parameters) -> None:
@@ -660,24 +660,21 @@ class WQP_Metadata(BaseMetadata):
     def site_info(self) -> tuple[DataFrame, WQP_Metadata] | None:
         """Site information for the query.
 
-        Populated when the query included ``sites``, ``site`` or
-        ``site_no`` (in that order of preference); ``None`` otherwise.
+        Populated (via :func:`dataretrieval.wqp.what_sites`) when the query
+        included a ``siteid`` (the WQP site identifier, e.g.
+        ``"USGS-05586100"``); ``None`` otherwise.
 
         Returns
         -------
         df : ``pandas.DataFrame``
-            Formatted requested data from calling ``wqp.what_sites``.
+            Site data returned by ``wqp.what_sites``.
         md : :obj:`dataretrieval.wqp.WQP_Metadata`
             A WQP_Metadata object.
         """
-        if "sites" in self._parameters:
-            return what_sites(sites=self._parameters["sites"])
-        elif "site" in self._parameters:
-            return what_sites(sites=self._parameters["site"])
-        elif "site_no" in self._parameters:
-            return what_sites(sites=self._parameters["site_no"])
-        else:
+        siteid = self._parameters.get("siteid")
+        if siteid is None:
             return None
+        return what_sites(siteid=siteid)
 
 
 def _check_kwargs(kwargs):

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -41,6 +41,10 @@ def test_get_results(httpx_mock):
     assert md.header.get("mock_header") == "value"
     assert md.comment is None
     assert df["ActivityStartDateTime"].notna().all()
+    # Regression: the getter must thread the query kwargs into the metadata
+    # (it previously built WQP_Metadata(response), dropping them), so that
+    # md.site_info has a siteid to look up instead of always returning None.
+    assert md._parameters.get("siteid") == "WIDNR_WQX-10032762"
 
 
 def test_get_results_WQX3(httpx_mock):
@@ -269,7 +273,7 @@ def test_wqp_metadata_site_info_is_accessible_property():
 
 
 def test_wqp_metadata_site_info_routes_to_what_sites(monkeypatch):
-    """When the query carried ``sites`` (or ``site``/``site_no``),
+    """When the query carried a ``siteid`` (WQP's site identifier),
     ``site_info`` delegates to ``wqp.what_sites`` with that identifier."""
     import dataretrieval.wqp as wqp_mod
 
@@ -280,5 +284,5 @@ def test_wqp_metadata_site_info_routes_to_what_sites(monkeypatch):
         return "SENTINEL"
 
     monkeypatch.setattr(wqp_mod, "what_sites", fake_what_sites)
-    assert _wqp_metadata(sites="USGS-05427718").site_info == "SENTINEL"
-    assert captured == {"sites": "USGS-05427718"}
+    assert _wqp_metadata(siteid="USGS-05427718").site_info == "SENTINEL"
+    assert captured == {"siteid": "USGS-05427718"}


### PR DESCRIPTION
## Problem

`WQP_Metadata.site_info` **never returned anything** — it was always `None`, for every query. Two compounding bugs:

1. **The call sites passed no parameters.** All nine WQP getters built `WQP_Metadata(response)` (no `**kwargs`), so `self._parameters` was always `{}` and the property always fell through to `else: return None`. NWIS does it correctly — `NWIS_Metadata(response, **kwargs)`. *(PR #295 fixed the property's location — it had been a discarded local function nested in `__init__` — but the call sites still dropped the params, so the feature remained dead; that PR's test even asserted `site_info is None`, which masked it.)*

2. **The property keyed on the wrong parameter.** It checked `sites`/`site`/`site_no` and called `what_sites(sites=...)`, but WQP's site identifier is **`siteid`** (per the docstring and tests, e.g. `get_results(siteid="WIDNR_WQX-10032762")`). So even with params threaded through, it could never match a real WQP query.

## Fix

- All getters now pass the query kwargs: `WQP_Metadata(response, **kwargs)`.
- `site_info` keys on `siteid` and calls `what_sites(siteid=...)`.
- Corrected the class docstring (`comment` not `comments`; `WQP_Metadata` not `NWIS_Metadata`; `siteid` not `sites`).

## Verification

- **Live API:** `df, md = what_sites(siteid="WIDNR_WQX-10032762")` → `md._parameters` now carries `siteid`, and `md.site_info` returns a populated `(DataFrame, WQP_Metadata)` tuple (previously `None`).
- **Tests:** updated the routing test to the correct `siteid` key; added a regression assertion that `get_results` threads `siteid` into the metadata. All 14 `wqp` tests pass; `ruff` clean.

> Note: accessing `md.site_info` issues a live `what_sites` request (by design) and carries that call's legacy/WQX3 warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
