### PR TITLE
fix(waterdata): naive datetime filters shifted an hour across the DST boundary

### DIFF
--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -223,7 +223,7 @@ def _parse_datetime(value: str) -> datetime | None:
     return None
 
 
-def _format_one(dt, *, date: bool, local_tz) -> str | None:
+def _format_one(dt, *, date: bool) -> str | None:
     """Format a single datetime element for inclusion in the API time arg."""
     if pd.isna(dt) or dt == "" or dt is None:
         return ".."
@@ -232,7 +232,11 @@ def _format_one(dt, *, date: bool, local_tz) -> str | None:
         return None
     if date:
         return parsed.strftime("%Y-%m-%d")
-    aware = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=local_tz)
+    # Naive inputs are interpreted in the system local zone (for backwards
+    # compatibility). Use ``.astimezone()`` rather than a fixed offset so each
+    # value is resolved against the DST rules for ITS OWN date — a frozen
+    # ``datetime.now()`` offset shifted off-season inputs by an hour.
+    aware = parsed if parsed.tzinfo is not None else parsed.astimezone()
     return aware.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
@@ -317,12 +321,8 @@ def _format_api_dates(
             return single
 
     # Half-bounded ranges: NA endpoints render as ".."; any unparseable non-NA
-    # element invalidates the range. Resolve the local tz only now — after the
-    # all-NA / duration / interval guards above have had their chance to return.
-    local_timezone = datetime.now().astimezone().tzinfo
-    formatted = [
-        _format_one(dt, date=date, local_tz=local_timezone) for dt in datetime_input
-    ]
+    # element invalidates the range.
+    formatted = [_format_one(dt, date=date) for dt in datetime_input]
     if any(f is None for f in formatted):
         return None
     return "/".join(formatted)


### PR DESCRIPTION
## Problem

`_format_api_dates` resolved the local timezone **once**, as a frozen offset from "now":

```python
local_timezone = datetime.now().astimezone().tzinfo   # e.g. timezone(-4h) in summer
... parsed.replace(tzinfo=local_timezone)             # applied to EVERY naive input
```

A fixed offset can't represent DST, so a naive datetime on a date whose DST status differs from *today* is shifted by an hour. Verified on an EDT (−04:00) machine:

```
time="2020-01-01 12:00:00"  ->  2020-01-01T16:00:00Z   # WRONG — January is EST (-05:00), should be 17:00:00Z
```

This skews the query window for `get_continuous` / `get_field_measurements` (`time`/`begin`/`end`) whenever the input date is in the other DST season.

## Fix

Interpret a naive input with `parsed.astimezone()`, which presumes the system local zone and uses the DST rules for **that input's own date**, then convert to UTC. Inputs that already carry an explicit offset (`Z`/`+HH:MM`) are unchanged.

## Verification

```
winter 2020-01-01 12:00 -> 2020-01-01T17:00:00Z   # now correct (EST -05:00)
summer 2020-07-01 12:00 -> 2020-07-01T16:00:00Z   # correct (EDT -04:00)
aware  +00:00            -> 2020-01-01T12:00:00Z   # offset honored
date-only / interval / duration  -> unchanged
```
16 existing date-formatting tests pass; `ruff` clean.

> No new unit test: the bug only manifests when the *test runner's* local zone observes DST, so a portable assertion would require mocking the system tz. Verified manually as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
