### PR TITLE
chore: misc cleanups from the package review (bbox docs, nwis, empty-list)

### DIFF
--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -283,7 +283,10 @@ def get_discharge_peaks(
 
     response = query_waterdata("peaks", format="rdb", ssl_check=ssl_check, **kwargs)
 
-    df = _read_rdb(response.text)
+    # Parse raw (read_rdb), not _read_rdb — the latter already runs
+    # format_response, and the explicit format_response(service="peaks") below
+    # does the peaks-specific formatting, so _read_rdb here was a redundant pass.
+    df = read_rdb(response.text, dtypes=_NWIS_RDB_DTYPES)
 
     return format_response(df, service="peaks", **kwargs), NWIS_Metadata(
         response, **kwargs
@@ -383,7 +386,7 @@ def query_waterdata(service: str, ssl_check: bool = True, **kwargs) -> httpx.Res
     request: ``httpx.Response``
         The response object from the API request to the web service
     """
-    major_params = ["site_no", "state_cd"]
+    major_params = ["site_no", "stateCd"]
     bbox_params = [
         "nw_longitude_va",
         "nw_latitude_va",

--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -189,7 +189,7 @@ def get_daily(
         axis (height or depth). Coordinates are assumed to be in crs 4326. The
         expected format is a numeric vector structured: c(xmin,ymin,xmax,ymax).
         Another way to think of it is c(Western-most longitude, Southern-most
-        latitude, Eastern-most longitude, Northern-most longitude).
+        latitude, Eastern-most longitude, Northern-most latitude).
     limit : numeric, optional
         The optional limit parameter is used to control the subset of the
         selected features that should be returned in each page. The maximum
@@ -700,7 +700,7 @@ def get_monitoring_locations(
         axis (height or depth). Coordinates are assumed to be in crs 4326. The
         expected format is a numeric vector structured: c(xmin,ymin,xmax,ymax).
         Another way to think of it is c(Western-most longitude, Southern-most
-        latitude, Eastern-most longitude, Northern-most longitude).
+        latitude, Eastern-most longitude, Northern-most latitude).
     limit : numeric, optional
         The optional limit parameter is used to control the subset of the
         selected features that should be returned in each page. The maximum
@@ -927,7 +927,7 @@ def get_time_series_metadata(
         axis (height or depth). Coordinates are assumed to be in crs 4326. The
         expected format is a numeric vector structured: c(xmin,ymin,xmax,ymax).
         Another way to think of it is c(Western-most longitude, Southern-most
-        latitude, Eastern-most longitude, Northern-most longitude).
+        latitude, Eastern-most longitude, Northern-most latitude).
     limit : numeric, optional
         The optional limit parameter is used to control the subset of the
         selected features that should be returned in each page. The maximum
@@ -1337,7 +1337,7 @@ def get_latest_continuous(
         axis (height or depth). Coordinates are assumed to be in crs 4326. The
         expected format is a numeric vector structured: c(xmin,ymin,xmax,ymax).
         Another way to think of it is c(Western-most longitude, Southern-most
-        latitude, Eastern-most longitude, Northern-most longitude).
+        latitude, Eastern-most longitude, Northern-most latitude).
     limit : numeric, optional
         The optional limit parameter is used to control the subset of the
         selected features that should be returned in each page. The maximum
@@ -1533,7 +1533,7 @@ def get_latest_daily(
         axis (height or depth). Coordinates are assumed to be in crs 4326. The
         expected format is a numeric vector structured: c(xmin,ymin,xmax,ymax).
         Another way to think of it is c(Western-most longitude, Southern-most
-        latitude, Eastern-most longitude, Northern-most longitude).
+        latitude, Eastern-most longitude, Northern-most latitude).
     limit : numeric, optional
         The optional limit parameter is used to control the subset of the
         selected features that should be returned in each page. The maximum
@@ -1639,10 +1639,11 @@ def get_field_measurements(
         A short code corresponding to the observing procedure for the field
         measurement.
     properties : string or iterable of strings, optional
-        A vector of requested columns to be returned from the query.  Available
-        options are: geometry, id, time_series_id, monitoring_location_id,
-        parameter_code, statistic_id, time, value, unit_of_measure,
-        approval_status, qualifier, last_modified
+        A vector of requested columns to be returned from the query. See the
+        field-measurements schema in the OpenAPI reference for the available
+        columns (e.g. geometry, id, monitoring_location_id, parameter_code,
+        value, unit_of_measure, approval_status, qualifier, last_modified):
+        https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=html#/field-measurements
     field_visit_id : string or iterable of strings, optional
         A universally unique identifier (UUID) for the field visit.
         Multiple measurements may be made during a single field visit.
@@ -1720,7 +1721,7 @@ def get_field_measurements(
         axis (height or depth). Coordinates are assumed to be in crs 4326. The
         expected format is a numeric vector structured: c(xmin,ymin,xmax,ymax).
         Another way to think of it is c(Western-most longitude, Southern-most
-        latitude, Eastern-most longitude, Northern-most longitude).
+        latitude, Eastern-most longitude, Northern-most latitude).
     limit : numeric, optional
         The optional limit parameter is used to control the subset of the
         selected features that should be returned in each page. The maximum
@@ -2257,7 +2258,7 @@ def get_samples(
             * Western-most longitude
             * Southern-most latitude
             * Eastern-most longitude
-            * Northern-most longitude
+            * Northern-most latitude
 
         Example: [-92.8,44.2,-88.9,46.0]
     countryFips : string or iterable of strings, optional

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -674,10 +674,13 @@ def _construct_api_requests(
         params = {k: v for k, v in kwargs.items() if k not in post_params}
     else:
         # GET with comma-separated values: join list/tuple values into one string.
+        # Skip empty lists/tuples so they're omitted rather than emitted as a
+        # filterless ``&param=`` (which the server reads as "match empty").
         post_params = {}
         params = {
             k: ",".join(str(x) for x in v) if isinstance(v, (list, tuple)) else v
             for k, v in kwargs.items()
+            if not (isinstance(v, (list, tuple)) and len(v) == 0)
         }
 
     _ogc_query_params(

--- a/tests/waterdata_test.py
+++ b/tests/waterdata_test.py
@@ -175,6 +175,16 @@ def test_construct_api_requests_multivalue_get():
     assert "parameter_code=00060%2C00065" in str(req.url)
 
 
+def test_construct_api_requests_omits_empty_list():
+    """An empty list value is omitted from the URL, not emitted as a filterless
+    ``&parameter_code=`` (which the server reads as 'match empty')."""
+    req = _construct_api_requests(
+        "daily", monitoring_location_id="USGS-05427718", parameter_code=[]
+    )
+    assert "parameter_code" not in str(req.url)
+    assert "monitoring_location_id=USGS-05427718" in str(req.url)
+
+
 def test_construct_api_requests_monitoring_locations_post():
     """monitoring-locations uses POST+CQL2 for multi-value params (API limitation)."""
     req = _construct_api_requests(


### PR DESCRIPTION
## Summary

A bundle of small, low-risk cleanups from the package review — two docs, three minor code fixes. No behavior change beyond the two noted.

| # | Fix | Kind |
|---|-----|------|
| 1 | **`bbox` docstring**: the 4th coordinate was labeled "Northern-most **longitude**"; for `[xmin, ymin, xmax, ymax]` it's the Northern-most **latitude**. Fixed across the OGC getters + `get_samples` (7 spots). | docs |
| 2 | **`get_field_measurements` `properties`** listed daily/continuous columns it doesn't have (`time_series_id`, `statistic_id`, `time`); now points to the field-measurements OpenAPI schema. | docs |
| 3 | **`nwis.get_discharge_peaks`** ran `format_response` twice (via `_read_rdb`, then again with `service="peaks"`); parse raw with `read_rdb` so it formats once. Behavior-preserving (the first pass was a no-op/redundant for peaks). | fix |
| 4 | **`nwis.query_waterdata`** validated a dead `state_cd` key while the docs, error message, and callers all use `stateCd`; aligned so a `stateCd`-only query is recognized as a major filter (this becomes load-bearing once #310 stops the always-inject that currently masks it). | fix |
| 5 | **`_construct_api_requests`** emitted an empty-list param as a filterless `&param=` (read by the server as "match empty"); now omitted. | fix |

## Verification

- bbox: 0 remaining "Northern-most longitude", 7 "Northern-most latitude".
- empty list: `parameter_code=[]` → omitted; `parameter_code=["00060"]` → present (regression test added).
- `query_waterdata("peaks", stateCd="HI")` now passes the major-filter check; a no-filter call still raises `TypeError`.
- Full `nwis` suite (47) passes; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
