### PR TITLE
refactor(api)!: access services via submodules, not the flattened top-level namespace

### DIFF
--- a/dataretrieval/__init__.py
+++ b/dataretrieval/__init__.py
@@ -1,3 +1,22 @@
+"""Discover and retrieve water data from U.S. federal hydrologic web services.
+
+Access each service through its submodule::
+
+    from dataretrieval import waterdata  # modern USGS Water Data API
+
+    df, meta = waterdata.get_daily(monitoring_location_id="USGS-05427718")
+
+    from dataretrieval import nwis  # legacy NWIS services
+
+    df, meta = nwis.get_dv(sites="05427718")
+
+Available service modules: ``waterdata``, ``wqp`` (Water Quality Portal),
+``nldi``, ``samples``, ``streamstats``, ``nadp``, and the deprecated ``nwis``.
+
+``nldi`` requires geopandas (``pip install dataretrieval[nldi]``) and is
+imported on demand: ``from dataretrieval import nldi``.
+"""
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:
@@ -5,10 +24,23 @@ try:
 except PackageNotFoundError:
     __version__ = "version-unknown"
 
-from dataretrieval.nadp import *
-from dataretrieval.nwis import *
-from dataretrieval.samples import *
-from dataretrieval.streamstats import *
-from dataretrieval.utils import *
-from dataretrieval.waterdata import *
-from dataretrieval.wqp import *
+from . import (
+    nadp,
+    nwis,
+    samples,
+    streamstats,
+    utils,
+    waterdata,
+    wqp,
+)
+
+__all__ = [
+    "nadp",
+    "nwis",
+    "samples",
+    "streamstats",
+    "utils",
+    "waterdata",
+    "wqp",
+    "__version__",
+]


### PR DESCRIPTION
## Problem

`dataretrieval/__init__.py` star-imports every service module:

```python
from dataretrieval.nwis import *
from dataretrieval.waterdata import *
from dataretrieval.wqp import *
...
```

This flattens **all** of their public functions into the top-level package namespace, so `dataretrieval.get_dv`, `dataretrieval.get_results`, etc. all resolve at the top level. Two problems:

1. **One large, ambiguous top-level namespace** — every service's functions share a single flat namespace.
2. **Silent name collisions** — `get_ratings` is defined in both `nwis` and `waterdata`, and `what_sites` in both `nwis` and `wqp`. With `import *`, whichever module is imported last wins and the other is silently shadowed. (mypy flags this as an incompatible re-import — see #314, which only *suppressed* it.)

## Change

Expose the **service submodules** instead of flattening their contents:

```python
from . import nadp, nwis, samples, streamstats, utils, waterdata, wqp
```

Callers go through the owning module — the pattern the **README, docs, and tests already use**:

```python
from dataretrieval import waterdata
df, meta = waterdata.get_ratings(...)   # modern

from dataretrieval import nwis
df, meta = nwis.get_ratings(...)        # legacy — now unambiguous
```

- `dataretrieval.<module>` and `from dataretrieval import <module>` work for every service.
- `__version__` is unchanged.
- `nldi` stays import-on-demand (it requires the optional `geopandas`), exactly as before — `from dataretrieval import nldi`.
- The `get_ratings` / `what_sites` collision is now **structurally impossible** — each lives only under its module. This resolves at the source what #314 had to suppress with a `# type: ignore`.

## Breaking change

Top-level function access is removed:

| Before | After |
|---|---|
| `dataretrieval.get_dv(...)` | `dataretrieval.nwis.get_dv(...)` |
| `dataretrieval.get_results(...)` | `dataretrieval.wqp.get_results(...)` |
| `dataretrieval.get_ratings(...)` | `dataretrieval.waterdata.get_ratings(...)` (or `nwis`) |
| `dataretrieval.NoSitesError` | `dataretrieval.utils.NoSitesError` |

If a softer migration is preferred, a module-level `__getattr__` shim could keep the old names working for one release with a `DeprecationWarning` — happy to add that instead of the hard removal.

## Verification

- New access pattern asserted directly: top-level functions are gone; both `get_ratings` and both `what_sites` are reachable via their modules; `from dataretrieval import waterdata` and explicit `nldi` import work; `__version__` preserved.
- **Full test suite: 469 passed, 2 skipped** — the tests already use module-qualified access, so nothing needed changing.
- README and docs (per-module `automodule` directives) already use this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
