### PR TITLE
fix(wqp): WQP_Metadata.variable_info returns None instead of raising NotImplementedError

### DIFF
--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -202,7 +202,15 @@ def _attach_datetime_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 
 class BaseMetadata:
-    """Base class for metadata.
+    """Base class for the metadata returned alongside a service's data.
+
+    A concrete value object holding the response URL, query time, and headers;
+    the modern ``waterdata`` getters return it directly.
+
+    ``site_info`` and ``variable_info`` are legacy hooks: the ``nwis`` / ``wqp``
+    metadata subclasses override them to look up site (or, historically,
+    variable) details for the query. They are not part of the modern
+    ``waterdata`` contract, so on the base they raise ``NotImplementedError``.
 
     Attributes
     ----------
@@ -212,7 +220,6 @@ class BaseMetadata:
         Response elapsed time
     header: httpx.Headers
         Response headers
-
     """
 
     def __init__(self, response) -> None:

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -676,6 +676,13 @@ class WQP_Metadata(BaseMetadata):
             return None
         return what_sites(siteid=siteid)
 
+    @property
+    def variable_info(self) -> None:
+        """WQP exposes no variable/parameter catalog through metadata, so this
+        is always ``None`` (overriding the :class:`~dataretrieval.utils.BaseMetadata`
+        stub, which would otherwise raise ``NotImplementedError``)."""
+        return None
+
 
 def _check_kwargs(kwargs):
     """Private function to check kwargs for unsupported parameters."""

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -272,6 +272,13 @@ def test_wqp_metadata_site_info_is_accessible_property():
     assert _wqp_metadata().site_info is None  # must NOT raise
 
 
+def test_wqp_metadata_variable_info_is_none():
+    """Regression: WQP has no variable catalog, so ``variable_info`` must
+    return ``None`` rather than inheriting (and raising) the
+    ``BaseMetadata.variable_info`` NotImplementedError stub."""
+    assert _wqp_metadata().variable_info is None  # must NOT raise
+
+
 def test_wqp_metadata_site_info_routes_to_what_sites(monkeypatch):
     """When the query carried a ``siteid`` (WQP's site identifier),
     ``site_info`` delegates to ``wqp.what_sites`` with that identifier."""


### PR DESCRIPTION
## Problem

`WQP_Metadata` defines `site_info` but **not** `variable_info`, so accessing `wqp_md.variable_info` falls through to the `BaseMetadata.variable_info` stub and raises `NotImplementedError` — even though WQP simply has no variable/parameter catalog to expose. (`NWIS_Metadata.variable_info` returns `None` with a deprecation warning; WQP had nothing.)

## Change

- Add `WQP_Metadata.variable_info` returning `None`, mirroring how `site_info` returns `None` when the query carried no `siteid`.
- Document on `BaseMetadata` that `site_info` / `variable_info` are **legacy hooks** overridden by the `nwis`/`wqp` metadata subclasses, and are not part of the modern `waterdata` contract. `BaseMetadata` stays a **concrete value object** (the modern getters instantiate it directly), so it is deliberately *not* an `abc.ABC`.

No behavior change beyond WQP `variable_info` no longer raising; the base stub still raises `NotImplementedError` (contract preserved). Regression test added.

## Verification

`WQP_Metadata(...).variable_info` returns `None` without raising; `BaseMetadata(...).variable_info` still raises. 77 tests pass across `tests/utils_test.py` + `tests/wqp_test.py` + `tests/nwis_test.py`; ruff clean.

This is the small, zero-risk half of an architecture review's findings; a separate PR decomposes the `waterdata/utils.py` god-module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
