### PR TITLE
fix(waterdata): drop id from wire `properties` so daily/continuous don't 400

### DIFF
--- a/dataretrieval/waterdata/api.py
+++ b/dataretrieval/waterdata/api.py
@@ -3007,8 +3007,9 @@ def get_cql(
 
     properties_list = _as_str_list(properties, "properties")
 
-    # Translate user-facing names (``daily_id``/``id``) to the wire ``id`` the
-    # OGC API expects, matching the typed getters.
+    # Drop id aliases (``daily_id``/``id``) and ``geometry`` from the wire
+    # ``properties`` (the feature ``id`` is always returned and renamed
+    # downstream), matching the typed getters.
     wire_properties = _switch_properties_id(properties_list, output_id, service)
 
     req = _construct_cql_request(

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -187,14 +187,12 @@ def _switch_properties_id(
     if not properties:
         return []
     service_id = service.replace("-", "_") + "_id"
-    service_id_singular = ""
-    if service.endswith("s"):
-        service_id_singular = service[:-1].replace("-", "_") + "_id"
     # The feature ``id`` always comes back (renamed to the service id
-    # downstream) and several collections now reject it as a selectable
+    # downstream) and several collections reject it as a selectable
     # property; ``geometry`` is controlled by ``skip_geometry``. Drop both,
-    # plus every service-specific id alias.
-    drop = {"id", "geometry", id_name, service_id, service_id_singular}
+    # plus the service-specific id column (``id_name``) and the name derived
+    # straight from the service (``service_id``).
+    drop = {"id", "geometry", id_name, service_id}
     normalized = (p.replace("-", "_") for p in properties)
     return [p for p in normalized if p not in drop]
 

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -147,13 +147,19 @@ def _switch_properties_id(
     properties: list[str] | None, id_name: str, service: str
 ) -> list[str]:
     """
-    Switch properties id from its package-specific identifier to the
-    standardized "id" name that the API recognizes.
+    Build the wire ``properties`` list, dropping every id alias and
+    ``geometry``.
 
-    Replaces any service-specific id name in `properties` with "id",
-    normalizes remaining hyphens to underscores, and drops the "geometry"
-    and service-id entries. Returns an empty list when `properties` is empty
-    or None.
+    The feature ``id`` is always returned and is renamed to the
+    service-specific id column (e.g. ``daily_id``) in post-processing, so
+    it must not be requested as a property: several collections (e.g.
+    ``daily``, ``continuous``) reject ``id`` in ``properties`` with an
+    HTTP 400. ``geometry`` is likewise excluded because it is controlled
+    by ``skip_geometry``. Any service-specific id name (``daily_id``,
+    ``monitoring_location_id``, …) and the bare ``id`` are dropped, and
+    remaining hyphens are normalized to underscores. Returns an empty
+    list when `properties` is empty or None — the URL then omits the
+    ``properties`` filter and the result is shaped by :func:`_arrange_cols`.
 
     Parameters
     ----------
@@ -161,34 +167,36 @@ def _switch_properties_id(
         A list containing the properties or column names to be pulled from the
         service, or None.
     id_name : str
-        The name of the specific identifier key to look for.
+        The service-specific id column name to drop (e.g. ``daily_id``).
     service : str
         The service name.
 
     Returns
     -------
     List[str]
-        The modified list with id names standardized to "id".
+        The wire ``properties`` with id aliases and ``geometry`` removed
+        and hyphens normalized.
 
     Examples
     --------
-    For service "monitoring-locations", it will look for
-    "monitoring_location_id" and change
-    it to "id".
+    For service "daily" with ``properties=["daily_id", "value", "geometry"]``,
+    returns ``["value"]`` — ``daily_id`` and ``geometry`` are dropped, while
+    the ``daily_id`` column still appears in the result, renamed from the
+    always-returned feature ``id``.
     """
     if not properties:
         return []
     service_id = service.replace("-", "_") + "_id"
-    last_letter = service[-1]
     service_id_singular = ""
-    if last_letter == "s":
-        service_singular = service[:-1]
-        service_id_singular = service_singular.replace("-", "_") + "_id"
-    # Replace id fields with "id"
-    id_fields = [service_id, service_id_singular, id_name]
-    properties = ["id" if p in id_fields else p.replace("-", "_") for p in properties]
-    # Remove unwanted fields
-    return [p for p in properties if p not in ["geometry", service_id]]
+    if service.endswith("s"):
+        service_id_singular = service[:-1].replace("-", "_") + "_id"
+    # The feature ``id`` always comes back (renamed to the service id
+    # downstream) and several collections now reject it as a selectable
+    # property; ``geometry`` is controlled by ``skip_geometry``. Drop both,
+    # plus every service-specific id alias.
+    drop = {"id", "geometry", id_name, service_id, service_id_singular}
+    normalized = (p.replace("-", "_") for p in properties)
+    return [p for p in normalized if p not in drop]
 
 
 _DATETIME_FORMATS = (

--- a/tests/waterdata_test.py
+++ b/tests/waterdata_test.py
@@ -470,7 +470,8 @@ def test_get_continuous():
         time="2025-01-01/2025-12-31",
     )
     assert isinstance(df, DataFrame)
-    assert "geometry" not in df.columns
+    # ``skip_geometry`` is unset, so the server includes geometry by default.
+    assert "geometry" in df.columns
     assert (
         df["time"].dtype.name.startswith("datetime64[")
         and "UTC" in df["time"].dtype.name


### PR DESCRIPTION
## Problem (CI is red on `main`)

The live `daily` and `continuous` integration tests began failing around Jun 11–12, independent of any code change:

- `test_get_daily_properties` / `_id` → `400: InvalidParameterValue. unknown properties specified`
- `test_get_continuous` → `assert 'geometry' not in df.columns` (geometry *is* present)

These are **live-API drift**, not a regression in the repo (main's last green CI ran Jun 10; the API changed after). They red every PR's `ubuntu` matrix until fixed.

## Root cause

I probed the live API to characterize the change:

| collection | `properties=id,value` | `properties=value` |
|---|---|---|
| `daily` | **400** | 200 |
| `continuous` | **400** | 200 |
| `latest-daily` | 200 | 200 |

1. **`id` is no longer a selectable property** on `daily`/`continuous` (the feature `id` is always returned anyway). `_switch_properties_id` translated the user-facing id column (`daily_id`) to `id` and **kept it in the wire `properties`**, so requests that listed the id column started 400ing. (`latest-daily` still tolerates `id`, which is why the CQL test kept passing.)
2. **Geometry is now included by default** when `skipGeometry` is unset — which the library already documents (`skip_geometry=None` "leaves skipGeometry unset (the server defaults to including geometry)").

## Fix

- **`_switch_properties_id`** now **drops** every id alias (`id`, the service id like `daily_id`, and its singular form) plus `geometry` from the wire `properties`, instead of translating to `id` and keeping it. The feature `id` always comes back and is renamed to the service id column in `_arrange_cols`, so it never needs to be requested. **This matches the R `dataRetrieval` package's `switch_properties_id`** (which removes `id`/`geometry`).
  - **User-facing behavior is unchanged**: callers still pass `daily_id`/`id` in `properties` and get the same output columns — only the request the chunker sends is corrected.
- **`test_get_continuous`**: updated the stale geometry assertion to match the documented default (server includes geometry when `skip_geometry` is unset). The user-facing default is intentionally **not** changed.

## Note on consistency (raised in review)

The R package excludes geometry for `continuous` by *forcing* `skipGeometry = TRUE` in `read_waterdata_continuous` (high-frequency data → geometry per row is pure bloat). Python's `get_continuous` instead defaults `skip_geometry=None` (server default). Aligning Python would be a **user-facing default change**, which is deliberately out of scope here — flagging it as a possible follow-up enhancement.

## Verification

The 3 originally-failing tests pass against the live API, and the related id/geometry tests stay green (`test_get_daily_no_geometry`, `test_get_cql_properties_id_translation`, `test_get_latest_daily_properties_geometry`, …). Full `waterdata_test.py` (75) plus `waterdata_utils`/`filters`/`chunking` suites pass; `ruff` and `mypy --strict dataretrieval/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)