### PR TITLE
test(waterdata): rerun flaky transient 5xx/429 from the chunked fan-out

### DIFF
--- a/tests/waterdata_test.py
+++ b/tests/waterdata_test.py
@@ -53,7 +53,14 @@ pytestmark = pytest.mark.flaky(
     reruns=2,
     reruns_delay=5,
     only_rerun=[
-        r"(?:RateLimited|RuntimeError):\s*(?:429|5\d\d):",  # _raise_for_non_200 output
+        # Transient HTTP errors (429 / 5xx) on the direct path: RateLimited /
+        # ServiceUnavailable carry a "<status>: ..." message (the RuntimeError
+        # shape is kept for any legacy call site).
+        r"(?:RateLimited|ServiceUnavailable|RuntimeError):\s*(?:429|5\d\d):",
+        # The chunked fan-out wraps a transient sub-request as a ChunkInterrupted
+        # subclass (QuotaExhausted for 429, ServiceInterrupted for 5xx), whose
+        # message has no leading status token.
+        r"(?:QuotaExhausted|ServiceInterrupted):",
         r"Connect(ion)?Error",  # requests' ConnectionError + httpx' ConnectError
         r"ReadTimeout|ConnectTimeout|Timeout",
     ],


### PR DESCRIPTION
## Problem
The live `tests/waterdata_test.py` suite reruns transient HTTP failures via `pytest.mark.flaky(only_rerun=[...])`, but the patterns only match the **direct-path** shapes `RateLimited:`/`RuntimeError: 5xx:`. Two transient sources are no longer covered:

- **Chunked fan-out:** a transient 5xx/429 in a sub-request is wrapped as a `ChunkInterrupted` subclass — `ServiceInterrupted` (5xx) / `QuotaExhausted` (429) — from the `#322` chunker work.
- **Current error taxonomy** (`#313`/`#319`): a direct 5xx now raises `ServiceUnavailable` (a `TransientError`), not `RuntimeError`.

None of these match `only_rerun`, so a **transient upstream 502** during a multi-value (chunked) `get_monitoring_locations` call fails CI outright instead of being retried. This surfaced on PR #324 (`test (ubuntu-latest, 3.13)` red with `ServiceInterrupted: ... Cause: ServiceUnavailable: 502: Bad Gateway`, while the other five matrix cells passed), but the gap is **pre-existing on `main`** — PR #324 only got unlucky enough to hit it.

## Fix
Add one `only_rerun` pattern covering `ServiceUnavailable` / `QuotaExhausted` / `ServiceInterrupted`.

Verified by simulation that it matches those transient exceptions (including a `ServiceInterrupted` wrapping a 502) **but not** deterministic failures (`HTTPError` 404, `AssertionError`); `RateLimited` (429) stays covered by the existing pattern.

## Notes
- Scope is intentionally minimal (one file, one pattern). `tests/ngwmn_test.py` (added by #324) carries the same `only_rerun` block and will want the identical pattern once that PR lands — worth a follow-up, or a shared constant to prevent drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)