### PR TITLE
ci(docs): serialize gh-pages deploys to fix the "cannot lock ref" race

### DIFF
--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -6,6 +6,15 @@ on:
   push:
   pull_request:
 
+# Serialize runs for the same ref so two near-simultaneous pushes to main
+# don't race to force-push gh-pages. Without this, the second deploy fails
+# with "cannot lock ref 'refs/heads/gh-pages'" because the first run advanced
+# the branch after the second had already read its tip. Queue rather than
+# cancel (cancel-in-progress: false) so every commit's docs still deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The **Sphinx Docs Build** workflow failed on `main` (run for `018d9c2a`, #338) — but **the build succeeded**; only the **Deploy to GitHub Pages** step failed:

```
! [remote rejected] ... -> gh-pages
  (cannot lock ref 'refs/heads/gh-pages': is at 9249ee62... but expected 0d61e220...)
error: failed to push some refs
```

Two commits landed on `main` ~2 minutes apart (`3ccdef3e` at 13:27 and `018d9c2a` at 13:29), spawning two docs runs that both force-push `gh-pages` via `JamesIves/github-pages-deploy-action`. The newer run read the gh-pages tip (`0d61e220`); the older run advanced it to `9249ee62` first; the newer run's force-push was then rejected by the ref-lock. This is a race, and it recurs whenever two commits land on `main` close together.

## Fix

Add a workflow-level `concurrency` group keyed on the ref so runs targeting the same branch **serialize** instead of racing:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: false
```

- Two pushes to `main` now queue: the second run waits for the first to finish deploying, then force-pushes on top — no lock contention.
- `cancel-in-progress: false` keeps the latest commit's docs guaranteed to deploy (rather than cancelling an in-flight build).
- PR builds key on their own ref (`refs/pull/N/merge`) and don't run the deploy step, so they're unaffected and still run in parallel.

This is the deploy-action maintainer's recommended remedy for the `cannot lock ref` error.

## Notes

- Workflow-only change; no library or docs-content changes.
- Can't be fully exercised until two commits race again on `main`, but it's the standard, well-understood fix and is YAML-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)