### PR TITLE
fix(waterdata): attach EPSG:4326 CRS to OGC GeoDataFrames

### DIFF
--- a/dataretrieval/ogc/shaping.py
+++ b/dataretrieval/ogc/shaping.py
@@ -31,6 +31,12 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Water Data OGC coordinates are published in WGS84, so attach that CRS where the
+# GeoDataFrame is built (otherwise the result is CRS-naive and ``to_crs`` /
+# spatial joins fail). Mirrors the constants in ``nldi`` (EPSG:4326) and ``nwis``
+# (EPSG:4269).
+_CRS = "EPSG:4326"
+
 # Whether geopandas is present is a static, environment-level fact, so warn
 # once here at import time rather than per query/chunk.
 if not GEOPANDAS:
@@ -141,7 +147,8 @@ def _get_resp_data(
     # a plain DataFrame. Features that already carry geometry (the common
     # sites case) are passed through without a per-feature dict copy.
     df = gpd.GeoDataFrame.from_features(
-        [f if "geometry" in f else {**f, "geometry": None} for f in features]
+        [f if "geometry" in f else {**f, "geometry": None} for f in features],
+        crs=_CRS,
     )
     # Mirror the non-geopandas branch's defensive ``f.get("id")`` so a feature
     # missing a top-level ``id`` yields None rather than a KeyError.

--- a/dataretrieval/waterdata/stats.py
+++ b/dataretrieval/waterdata/stats.py
@@ -22,6 +22,7 @@ from dataretrieval.ogc.engine import (
     _run_sync,
 )
 from dataretrieval.ogc.shaping import (
+    _CRS,
     GEOPANDAS,
     _attach_coordinates,
     _empty_feature_frame,
@@ -111,7 +112,8 @@ def _handle_nesting(
         # can't ``KeyError`` on a stats feature that omits geometry — mirrors
         # the guard in :func:`engine._get_resp_data`.
         df = gpd.GeoDataFrame.from_features(
-            [f if "geometry" in f else {**f, "geometry": None} for f in features]
+            [f if "geometry" in f else {**f, "geometry": None} for f in features],
+            crs=_CRS,
         ).drop(columns=["data"], errors="ignore")
 
     # Unnest json features, properties, data, and values while retaining necessary

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -596,6 +596,60 @@ def test_get_resp_data_empty_preserves_geopd_type():
     assert isinstance(result, _Sentinel)
 
 
+def test_get_resp_data_attaches_wgs84_crs():
+    """A geometry-bearing Water Data page should come back tagged as
+    EPSG:4326 (the CRS the coordinates are published in), so callers can
+    run ``to_crs`` / spatial joins without first patching in a CRS by
+    hand. Regression for the ``.crs is None`` reported in issue #342."""
+    geopandas = pytest.importorskip("geopandas")
+
+    resp = mock.MagicMock()
+    resp.json.return_value = {
+        "numberReturned": 1,
+        "features": [
+            {
+                "type": "Feature",
+                "id": "USGS-01",
+                "geometry": {"type": "Point", "coordinates": [-76.5, 39.2]},
+                "properties": {"monitoring_location_id": "USGS-01"},
+            }
+        ],
+    }
+    df = _get_resp_data(resp, geopd=True)
+    assert isinstance(df, geopandas.GeoDataFrame)
+    assert df.crs == "EPSG:4326"
+
+
+def test_handle_nesting_attaches_wgs84_crs():
+    """The stats path builds its GeoDataFrame the same way, so it should
+    carry EPSG:4326 too (issue #342)."""
+    geopandas = pytest.importorskip("geopandas")
+
+    body = {
+        "next": None,
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [-76.5, 39.2]},
+                "properties": {
+                    "monitoring_location_id": "USGS-01",
+                    "data": [
+                        {
+                            "parameter_code": "00060",
+                            "unit_of_measure": "ft^3/s",
+                            "parent_time_series_id": "ts-1",
+                            "values": [{"statistic_id": "mean", "value": 10.0}],
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+    df = _handle_nesting(body, geopd=True)
+    assert isinstance(df, geopandas.GeoDataFrame)
+    assert df.crs == "EPSG:4326"
+
+
 def test_handle_nesting_tolerates_missing_features_key():
     """A 200 response with a body that doesn't carry ``features`` at
     all (rare but seen in error envelopes) must also short-circuit

--- a/tests/waterdata_utils_test.py
+++ b/tests/waterdata_utils_test.py
@@ -603,18 +603,16 @@ def test_get_resp_data_attaches_wgs84_crs():
     hand. Regression for the ``.crs is None`` reported in issue #342."""
     geopandas = pytest.importorskip("geopandas")
 
-    resp = mock.MagicMock()
-    resp.json.return_value = {
-        "numberReturned": 1,
-        "features": [
+    resp = _resp_ok(
+        [
             {
                 "type": "Feature",
                 "id": "USGS-01",
                 "geometry": {"type": "Point", "coordinates": [-76.5, 39.2]},
                 "properties": {"monitoring_location_id": "USGS-01"},
             }
-        ],
-    }
+        ]
+    )
     df = _get_resp_data(resp, geopd=True)
     assert isinstance(df, geopandas.GeoDataFrame)
     assert df.crs == "EPSG:4326"


### PR DESCRIPTION
This fixes #342. The waterdata getters build their GeoDataFrame with gpd.GeoDataFrame.from_features(...) but never pass a crs, so the result comes back with .crs of None even though the coordinates are published in EPSG:4326 and the get_monitoring_locations docstring says as much. That leaves the frame CRS-naive, so to_crs and spatial joins raise on an otherwise valid result, and it's out of step with the nldi (EPSG:4326) and nwis (EPSG:4269) modules that already tag theirs.

I added a shared _CRS constant in ogc/shaping.py and pass it at both build sites (shaping and waterdata/stats), mirroring how nldi/nwis do it. I confirmed the fix with new offline regression tests that fail before the change (crs is None) and pass after (crs is EPSG:4326) for both the sites path and the stats path; the rest of the waterdata suite and ruff stay green. Thanks for taking a look.