### PR TITLE
ci(docs): stop installing an unused TeX stack; bound the docs job

### DIFF
--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -18,6 +18,14 @@ concurrency:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    # A normal build is ~6 min, nearly all of it executing the example
+    # notebooks against live USGS services. The cap is well above that but far
+    # below the 6 h default, so a build that stops making progress -- a slow apt
+    # mirror, a service that never answers -- fails while the queue behind it is
+    # still short. Serialized runs (see ``concurrency`` above) queue rather than
+    # cancel, so an unbounded run blocks every later commit's docs, not just its
+    # own.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -34,7 +42,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[doc,nldi]
           ipython kernel install --name "python3" --user
-          sudo apt update -y && sudo apt install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended dvipng pandoc
+          # pandoc only: nbsphinx shells out to it to convert notebook markdown
+          # cells, so the build fails without it. The TeX stack this used to
+          # install alongside it (latexmk, texlive-*, dvipng -- ~266 MB) is not
+          # reachable from an HTML build: no math extension is configured and
+          # nothing renders math to images, so it was downloaded and never run.
+          # It was also the whole tail risk -- 127 packages off one apt mirror,
+          # which on a bad day delivered 314 MB at 37 KB/s and turned a 6 min
+          # build into 150 min. Restore it only alongside a builder that needs
+          # it (``latexpdf``), not for HTML.
+          sudo apt update -y && sudo apt install -y pandoc
           (cd docs && make html)
       - name: Debug
         run: |


### PR DESCRIPTION
## Summary

The docs build on `main` ran **150 minutes** instead of its usual ~6. It was not a code regression and not the notebooks.

The commit it ran on ([#356](https://github.com/DOI-USGS/dataretrieval-python/pull/356)) touched only CI config and `pyproject.toml` — `git diff f7c248b7 deba1331 -- docs/ demos/ dataretrieval/` is **empty**, so the build inputs were byte-identical to the run before it, which took 6m28s.

Timing the two runs against each other localizes it precisely:

| phase | fast run (6m25s) | hung run (150m) |
|---|---|---|
| `apt` download (127 pkgs) | **0.3 min** | **143.8 min** |
| notebook execution | 3.7 min | 3.7 min |

Notebook execution was identical. The entire difference was `apt` fetching the same 314 MB at an effective **37 KB/s** off a slow `azure.archive.ubuntu.com` mirror. Single packages stalled for over 20 minutes each (`mupdf-tools` 23.6 min, `openjdk-21-jre-headless` 22.2 min).

## What this changes

**1. Drop the TeX stack (~266 MB of the 314 MB).** An HTML build never reaches it — no math extension is configured in `docs/source/conf.py` (neither `mathjax` nor `imgmath`), and nothing renders math to images. `latexmk`, `texlive-*`, and `dvipng` were downloaded and never executed, yet accounted for 5 of the 6 slowest single-package waits. This removes the tail risk rather than trimming it: with `pandoc` alone there is no longer a large download to be slow.

`pandoc` is kept — `nbsphinx` shells out to it for notebook markdown cells, and the build fails with `PandocMissing` without it (verified).

**2. Add `timeout-minutes: 30`.** The next slow mirror will find whatever is left, and the default is 6 hours. This matters more than it appears: runs are serialized on the ref (`concurrency`, `cancel-in-progress: false`), so an unbounded run doesn't just lose its own docs — it holds the queue for every commit behind it. That is why this surfaced as "docs are stuck on main" rather than as one slow run. A cell-level `nbsphinx_timeout` was considered and deliberately left out, since notebook execution was never the problem here.

## Test plan

- [x] `sphinx-build -b html` with TeX binaries off `PATH` → **build succeeded**
- [x] All **44 non-notebook HTML pages byte-identical** to a build with TeX present (`examples/` pages differ only because notebooks re-execute against live data)
- [x] Zero `math*.png` in either build — confirms nothing was rendering math via LaTeX
- [x] Confirmed `pandoc` is genuinely required (removing it fails with `PandocMissing`)
- [x] Workflow YAML parses; executed commands contain no `texlive`/`latexmk`/`dvipng`
- [ ] Confirm this PR's own docs run lands in the normal ~5 min range

🤖 Generated with [Claude Code](https://claude.com/claude-code)