### PR TITLE
fix: harden code-health checks and ratchets

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -48,7 +48,7 @@ jobs:
         # exit here means "findings", which are the point.
         continue-on-error: true
         run: |
-          pyscn analyze --json --no-open dataretrieval | tee pyscn-summary.txt
+          pyscn analyze --json --no-open dataretrieval 2>&1 | tee pyscn-summary.txt
           pyscn analyze --html --no-open dataretrieval >/dev/null
 
       - name: Check the analysis actually resolved the package
@@ -94,7 +94,11 @@ jobs:
           {
             echo '## Structural analysis'
             echo '```'
-            cat pyscn-summary.txt 2>/dev/null || echo 'pyscn produced no output'
+            if [[ -s pyscn-summary.txt ]]; then
+              cat pyscn-summary.txt
+            else
+              echo 'pyscn produced no output'
+            fi
             cat pyscn-sanity.txt 2>/dev/null || true
             echo '```'
             cat wily-summary.txt 2>/dev/null || true
@@ -113,6 +117,7 @@ jobs:
           path: |
             .pyscn/reports/
             pyscn-summary.txt
+            pyscn-sanity.txt
             wily-summary.txt
           retention-days: 90
           if-no-files-found: warn

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Complexity gate
         run: xenon --max-absolute C --max-modules B --max-average A dataretrieval
       - name: Cognitive complexity gate
-        run: complexipy --max-complexity-allowed 27 --failed dataretrieval
+        run: complexipy dataretrieval
       - name: Dependency-direction contracts
         # Rules and rationale live in .importlinter and the ADRs it cites.
         run: lint-imports

--- a/.importlinter
+++ b/.importlinter
@@ -27,7 +27,7 @@ layers =
     utils
     transport
     progress
-    codes | combining | rdb | response_metadata
+    _ambient | _response_metadata | codes | combining | rdb
     credentials
     exceptions
 ; Every top-level module must be placed in the stack deliberately. A new
@@ -94,6 +94,14 @@ source_modules =
     dataretrieval.ogc.shaping
 forbidden_modules =
     dataretrieval.ogc.engine
+
+[importlinter:contract:ogc-utils]
+name = OGC core does not depend on legacy utilities (ADR 0003)
+type = forbidden
+source_modules =
+    dataretrieval.ogc
+forbidden_modules =
+    dataretrieval.utils
 
 [importlinter:contract:nwis-quarantine]
 name = Deprecated NWIS has no dependents (ADR 0005)

--- a/.importlinter
+++ b/.importlinter
@@ -1,10 +1,10 @@
 ; Declarative dependency-direction contracts for ``dataretrieval``.
 ;
-; This file owns every rule that is purely a statement about the import graph.
-; ``tests/architecture_test.py`` owns the rules that are not: symbol-level
-; claims, ``__all__`` surfaces, AST shape, and the one boundary that must be
-; asserted positively. The split is deliberate and the two do not overlap --
-; a rule enforced twice is a rule that gets updated once.
+; This file owns dependency-direction rules. ``tests/architecture_test.py``
+; owns symbol-level claims, ``__all__`` surfaces, AST shape, positive imports,
+; and package-wide cycle detection (see ADR 0003). The split is deliberate and
+; the two do not overlap -- a rule enforced twice is a rule that gets updated
+; once.
 ;
 ; Run with ``lint-imports`` (installed by the ``[metrics]`` extra).
 
@@ -35,16 +35,6 @@ layers =
 exhaustive = True
 exhaustive_ignores =
     _version
-
-[importlinter:contract:acyclic]
-name = The runtime import graph is acyclic (ADR 0001)
-type = acyclic_siblings
-; Applied to the whole package, not just the two subsystems whose acyclicity
-; was previously asserted by hand. The claim held package-wide already; stating
-; it once at the root covers ``ogc`` and ``transport`` and every future
-; subpackage without a new rule per package.
-ancestors =
-    dataretrieval
 
 [importlinter:contract:ogc-consumers]
 name = Only NGWMN and Water Data consume the OGC subsystem (ADR 0003)
@@ -128,9 +118,9 @@ forbidden_modules =
 [importlinter:contract:waterdata-families]
 name = Water Data collection families do not reach through each other (ADR 0007)
 type = independence
-; Kept in step with ``_WATERDATA_FAMILIES`` in tests/architecture_test.py, which
-; derives the facade's expected export union from the same six modules. A
-; seventh family fails that test until it is listed there; add it here too.
+; This is the single collection-family inventory. ``tests/architecture_test.py``
+; reads it to derive the facade's expected export union, so adding a module here
+; brings it under both the independence contract and the facade check.
 modules =
     dataretrieval.waterdata.cql
     dataretrieval.waterdata.measurements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,15 +66,14 @@ repos:
   # Cognitive-complexity ratchet, the counterpart to xenon's cyclomatic one.
   # The two measure different things: xenon counts branches, complexipy counts
   # how hard the control flow is to hold in your head, so nesting and early
-  # exits weigh differently. 27 is the package's current maximum
-  # (``nldi.get_features``), so this holds the line rather than demanding a
+  # exits weigh differently. 25 is the package's current maximum
+  # (``nwis._read_json``), so this holds the line rather than demanding a
   # refactor. Unlike xenon this one is per-function, so scanning only the
   # changed files gives the same verdict CI gives for the whole package.
   - repo: https://github.com/rohaquinlop/complexipy-pre-commit
     rev: v6.2.0
     hooks:
       - id: complexipy
-        args: ["--max-complexity-allowed", "27", "--failed"]
         files: ^dataretrieval/.*\.py$
 
   # Dependency-direction contracts (ADR 0003, 0005, 0006, 0007). Complements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,11 +123,11 @@ mypy
 coverage run -m pytest tests/
 coverage report -m
 xenon --max-absolute C --max-modules B --max-average A dataretrieval
-complexipy --max-complexity-allowed 27 --failed dataretrieval
+complexipy dataretrieval
 lint-imports
 ```
 
-The last three come from `pip install -e .[metrics]`, and each has a pre-commit
+The last three come from `pip install -e '.[metrics]'`, and each has a pre-commit
 hook running the identical check, so a clean pre-commit run means CI agrees.
 
 `xenon` and `complexipy` are complexity ratchets: the thresholds are the
@@ -139,20 +139,20 @@ punishes nesting. Both name the offending block, so the fix is local -- usually
 extracting a branch rather than restructuring.
 
 `lint-imports` checks the dependency contracts declared in
-[`.importlinter`](.importlinter) against the *transitive* import graph: the
-layer stack, which modules may consume OGC, NGWMN's facade-only seam, the NWIS
-quarantine, collection-family independence, and package-wide acyclicity.
+[`.importlinter`](.importlinter) against the *transitive* import graph: the layer
+stack, which modules may consume OGC, NGWMN's facade-only seam, the NWIS
+quarantine, and collection-family independence.
 
 **That file is the only place dependency direction is enforced.** These rules
 were once asserted a second time in `tests/architecture_test.py` by hand-parsing
 the AST; that duplication is gone, and re-adding it would mean one rule with two
 homes that drift apart. What the tests still own is everything an import graph
 cannot see -- which *symbols* cross a seam, declared `__all__` surfaces, the AST
-shape of a facade, and the one boundary that must be asserted positively
-(`lint-imports` can forbid an edge, never require one). If you are adding a rule
-and it is purely "module A must not import module B", it belongs in
-`.importlinter`. A boundary that legitimately moves is one edit there, plus the
-ADR it cites.
+shape of a facade, boundaries that must be asserted positively (`lint-imports`
+can forbid an edge, never require one), and package-wide cycle detection (see
+ADR 0003). If you are adding a rule and it is purely "module A must not import
+module B", it belongs in `.importlinter`. A boundary that legitimately moves is
+one edit there, plus the ADR it cites.
 
 To see the *trend* rather than a pass/fail, that extra also installs
 [`wily`](https://github.com/tonybaloney/wily), which indexes metrics across git
@@ -182,9 +182,8 @@ clean up next?" -- including for an agent working on this repo, which gets a
 whole-package structural picture from one command:
 
 ```bash
-pip install -e .[health]     # its own extra: pyscn is a compiled binary with no
-                             # linux/aarch64 wheel, so it is kept out of the
-                             # extra the merge gates depend on
+pip install -e '.[health]'   # wheels: macOS ARM64, Linux x86-64, Windows x86-64
+                             # (no source distribution or other platform wheels)
 pyscn analyze dataretrieval  # HTML report, or --json for the numbers
 ```
 

--- a/dataretrieval/_ambient.py
+++ b/dataretrieval/_ambient.py
@@ -1,0 +1,44 @@
+"""Dependency-free scoped context values used by concurrent internals."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+
+class Ambient(Generic[_T]):
+    """A :class:`~contextvars.ContextVar` paired with a scoping contextmanager.
+
+    Bundles the var and its set/reset-token dance into one object, so an ambient
+    value needs a single declaration instead of a ``var`` + setter-function pair.
+    Read the current value with :meth:`get`; set it for a ``with`` block by
+    calling the instance. The previous value is restored on exit::
+
+        _base_url = Ambient("ogc_base_url", DEFAULT)
+        with _base_url(other):
+            _base_url.get()  # -> other
+    """
+
+    def __init__(self, name: str, default: _T) -> None:
+        self._var: ContextVar[_T] = ContextVar(name, default=default)
+
+    def get(self) -> _T:
+        """Return the current value, or the default outside an active scope."""
+        return self._var.get()
+
+    @contextmanager
+    def __call__(self, value: _T) -> Iterator[None]:
+        """Set the value for the duration of the ``with`` block."""
+        token = self._var.set(value)
+        try:
+            yield
+        finally:
+            self._var.reset(token)
+
+
+# Preserve the documented class path from the v1.2.0 utility API.
+Ambient.__module__ = "dataretrieval.utils"

--- a/dataretrieval/_response_metadata.py
+++ b/dataretrieval/_response_metadata.py
@@ -7,7 +7,7 @@ machinery, needing it meant inheriting that module's whole HTTP stack
 (transport, credentials, error policy) transitively. Here it costs its
 consumers nothing but ``httpx``.
 
-``dataretrieval.utils.BaseMetadata`` remains a working import.
+``dataretrieval.utils.BaseMetadata`` remains the public import.
 """
 
 from __future__ import annotations
@@ -15,8 +15,6 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
-
-__all__ = ["BaseMetadata"]
 
 
 class BaseMetadata:
@@ -66,3 +64,8 @@ class BaseMetadata:
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(url={self.url})"
+
+
+# Pickles created after this class moved must remain readable by releases where
+# its public import path was only ``dataretrieval.utils.BaseMetadata``.
+BaseMetadata.__module__ = "dataretrieval.utils"

--- a/dataretrieval/ngwmn.py
+++ b/dataretrieval/ngwmn.py
@@ -22,10 +22,10 @@ from typing import Any
 
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.codes.states import apply_state
 from dataretrieval.credentials import WATERDATA_BASE_URL
 from dataretrieval.ogc import OgcDialect, get_ogc_data, prepare_request_args
-from dataretrieval.response_metadata import BaseMetadata
 
 __all__ = [
     "get_sites",

--- a/dataretrieval/nldi.py
+++ b/dataretrieval/nldi.py
@@ -260,6 +260,38 @@ def get_features(
         >>> gdf = dataretrieval.nldi.get_features(lat=43.073051, long=-89.401230)
     """
 
+    url, query_params = _get_features_request(
+        data_source=data_source,
+        navigation_mode=navigation_mode,
+        distance=distance,
+        feature_source=feature_source,
+        feature_id=feature_id,
+        comid=comid,
+        lat=lat,
+        long=long,
+        stop_comid=stop_comid,
+    )
+
+    feature_collection = cast("dict[str, Any]", _query_nldi(url, query_params))
+    if as_json:
+        return feature_collection
+    gdf = _features_to_gdf(feature_collection)
+    return gdf
+
+
+def _get_features_request(
+    *,
+    data_source: str | None,
+    navigation_mode: str | None,
+    distance: int,
+    feature_source: str | None,
+    feature_id: str | None,
+    comid: int | None,
+    lat: float | None,
+    long: float | None,
+    stop_comid: int | None,
+) -> tuple[str, dict[str, str]]:
+    """Validate a feature origin and build its NLDI request parameters."""
     if (lat is None) != (long is None):
         raise ValueError("Both lat and long are required")
 
@@ -274,37 +306,29 @@ def get_features(
                 "Provide only one origin type - feature_source and feature_id cannot"
                 " be provided with lat or long"
             )
-        url = f"{NLDI_API_BASE_URL}/comid/position"
-        query_params = {"coords": f"POINT({long} {lat})"}
-    else:
-        if (comid is not None or data_source is not None) and navigation_mode is None:
-            raise ValueError(
-                "navigation_mode is required if comid or data_source is provided"
-            )
-        _validate_feature_source_comid(feature_source, feature_id, comid)
-        if data_source is not None:
-            _validate_data_source(data_source)
-        if feature_source is not None:
-            _validate_data_source(feature_source)
-        if navigation_mode:
-            navigation_mode = _validate_navigation_mode(navigation_mode)
-            if feature_source:
-                url = f"{NLDI_API_BASE_URL}/{feature_source}/{feature_id}/navigation"
-            else:
-                url = f"{NLDI_API_BASE_URL}/comid/{comid}/navigation"
-            url += f"/{navigation_mode}/{data_source}"
-            query_params = {"distance": str(distance)}
-            if stop_comid is not None:
-                query_params["stopComid"] = str(stop_comid)
-        else:
-            url = f"{NLDI_API_BASE_URL}/{feature_source}/{feature_id}"
-            query_params = {}
+        return f"{NLDI_API_BASE_URL}/comid/position", {"coords": f"POINT({long} {lat})"}
 
-    feature_collection = cast("dict[str, Any]", _query_nldi(url, query_params))
-    if as_json:
-        return feature_collection
-    gdf = _features_to_gdf(feature_collection)
-    return gdf
+    if (comid is not None or data_source is not None) and navigation_mode is None:
+        raise ValueError(
+            "navigation_mode is required if comid or data_source is provided"
+        )
+
+    _validate_feature_source_comid(feature_source, feature_id, comid)
+    if data_source is not None:
+        _validate_data_source(data_source)
+    if feature_source is not None:
+        _validate_data_source(feature_source)
+
+    if not navigation_mode:
+        return f"{NLDI_API_BASE_URL}/{feature_source}/{feature_id}", {}
+
+    navigation_mode = _validate_navigation_mode(navigation_mode)
+    origin = f"{feature_source}/{feature_id}" if feature_source else f"comid/{comid}"
+    url = f"{NLDI_API_BASE_URL}/{origin}/navigation/{navigation_mode}/{data_source}"
+    query_params = {"distance": str(distance)}
+    if stop_comid is not None:
+        query_params["stopComid"] = str(stop_comid)
+    return url, query_params
 
 
 # TODO: This function can cause a timeout error for some data sources

--- a/dataretrieval/nwis.py
+++ b/dataretrieval/nwis.py
@@ -16,8 +16,8 @@ from typing import Any, NoReturn, TypeVar, cast
 import httpx
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.rdb import read_rdb
-from dataretrieval.response_metadata import BaseMetadata
 
 from .utils import query
 

--- a/dataretrieval/ogc/chunking.py
+++ b/dataretrieval/ogc/chunking.py
@@ -82,6 +82,7 @@ import pandas as pd
 from anyio.from_thread import start_blocking_portal
 
 from dataretrieval import progress as _progress
+from dataretrieval._ambient import Ambient
 from dataretrieval.combining import (
     _combine_chunk_frames,
     _combine_chunk_responses,
@@ -90,10 +91,10 @@ from dataretrieval.exceptions import ConfigurationError
 from dataretrieval.transport.http import open_async_client
 from dataretrieval.transport.retry import _NO_RETRY, RetryPolicy
 from dataretrieval.transport.retry import retry_async as _retry
-from dataretrieval.utils import Ambient, _require_positive_int
 
 from .interruptions import ChunkInterrupted
 from .planning import ChunkPlan
+from .policy import _require_positive_int
 from .retry import _classify_chunk_error
 
 # Empirically the API replies HTTP 414 above ~8200 bytes of full URL —

--- a/dataretrieval/ogc/chunking.py
+++ b/dataretrieval/ogc/chunking.py
@@ -444,12 +444,16 @@ class ChunkedCall:
             The concatenated frame and the aggregated response, before
             :attr:`finalize` is applied.
         """
-        frames = [self._chunks[i][0] for i in sorted(self._chunks)]
+        return self._combine_frames(), self._combine_responses()
+
+    def _combine_frames(self) -> pd.DataFrame:
+        """Combine completed frames in deterministic sub-request order."""
+        return _combine_chunk_frames([self._chunks[i][0] for i in sorted(self._chunks)])
+
+    def _combine_responses(self) -> httpx.Response:
+        """Aggregate completed responses under the canonical request URL."""
         responses = [response for _, response in self._chunks.values()]
-        return (
-            _combine_chunk_frames(frames),
-            _combine_chunk_responses(responses, self.plan.canonical_url),
-        )
+        return _combine_chunk_responses(responses, self.plan.canonical_url)
 
     @property
     def partial_frame(self) -> pd.DataFrame:
@@ -458,7 +462,7 @@ class ChunkedCall:
 
         Live — recomputed on each access so it reflects current state
         across resume attempts. Deliberately the *raw* combined frame
-        (``_combine_raw``), NOT the finalized result: this is a cheap,
+        (``_combine_frames``), NOT the finalized result: this is a cheap,
         side-effect-free snapshot for inspecting partial progress, so
         reading it (or building a :class:`ChunkInterrupted` around it)
         never triggers ``finalize`` work — which for OGC getters includes
@@ -471,9 +475,7 @@ class ChunkedCall:
             Combined frame of completed sub-requests, or an empty
             ``DataFrame`` when nothing has completed.
         """
-        if not self._chunks:
-            return pd.DataFrame()
-        return self._combine_raw()[0]
+        return self._combine_frames() if self._chunks else pd.DataFrame()
 
     @property
     def partial_response(self) -> httpx.Response | None:
@@ -491,9 +493,7 @@ class ChunkedCall:
             Aggregated response when at least one sub-request has
             completed, ``None`` otherwise.
         """
-        if not self._chunks:
-            return None
-        return self._combine_raw()[1]
+        return self._combine_responses() if self._chunks else None
 
     def _pending(self) -> Iterator[tuple[int, dict[str, Any]]]:
         """

--- a/dataretrieval/ogc/context.py
+++ b/dataretrieval/ogc/context.py
@@ -7,8 +7,8 @@ travel as context variables -- which also makes them safe under the concurrent
 fan-out, where a thread-global would not be.
 """
 
+from dataretrieval._ambient import Ambient
 from dataretrieval.ogc.policy import DEFAULT_DIALECT, OGC_API_URL, OgcDialect
-from dataretrieval.utils import Ambient
 
 # Optional cap on rows accumulated by one paginated request.
 _row_cap: Ambient[int | None] = Ambient("ogc_row_cap", None)

--- a/dataretrieval/ogc/engine.py
+++ b/dataretrieval/ogc/engine.py
@@ -348,6 +348,7 @@ def get_ogc_data(
         max_rows=max_rows,
         extra_id_cols=extra_id_cols,
         dialect=dialect,
+        base_url=base_url,
     )
     with (
         _progress.progress_context(service=service, target_url=base_url),

--- a/dataretrieval/ogc/engine.py
+++ b/dataretrieval/ogc/engine.py
@@ -37,6 +37,7 @@ import pandas as pd
 
 import dataretrieval.ogc.chunking as chunking
 import dataretrieval.progress as _progress
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.credentials import without_embedded_credentials
 from dataretrieval.ogc.chunking import get_active_client
 from dataretrieval.ogc.context import _row_cap
@@ -46,33 +47,21 @@ from dataretrieval.ogc.policy import (
     DEFAULT_DIALECT,
     OGC_API_URL,
     OgcDialect,
-)
-
-# Frozen legacy compatibility surface; tests prevent new request-side re-exports.
-from dataretrieval.ogc.requests import (  # noqa: F401
-    _NO_NORMALIZE_PARAMS,
-    _as_str_list,
-    _check_monitoring_location_id,
-    _construct_api_requests,
-    _construct_cql_request,
-    _cql2_param,
-    _dialect,
-    _get_args,
-    _normalize_str_iterable,
-    _ogc_base_url,
-    _ogc_query_params,
-    _switch_arg_id,
-    _switch_properties_id,
-    prepare_request_args,
-)
-from dataretrieval.ogc.shaping import GEOPANDAS, _finalize_ogc, _get_resp_data
-from dataretrieval.response_metadata import BaseMetadata
-from dataretrieval.transport.pagination import paginate
-from dataretrieval.transport.sync import run_sync
-from dataretrieval.utils import (
-    _default_headers,  # noqa: F401  — compatibility re-export for tests
     _require_positive_int,
 )
+
+# Request construction stays in its canonical module; the engine imports only
+# the symbols its orchestration uses.
+from dataretrieval.ogc.requests import (
+    _construct_api_requests,
+    _dialect,
+    _ogc_base_url,
+    _switch_arg_id,
+    _switch_properties_id,
+)
+from dataretrieval.ogc.shaping import GEOPANDAS, _finalize_ogc, _get_resp_data
+from dataretrieval.transport.pagination import paginate
+from dataretrieval.transport.sync import run_sync
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)

--- a/dataretrieval/ogc/errors.py
+++ b/dataretrieval/ogc/errors.py
@@ -11,9 +11,6 @@ from __future__ import annotations
 import httpx
 
 from dataretrieval.exceptions import error_for_status
-from dataretrieval.transport.pagination import (
-    paginated_failure_message as _paginated_failure_message,  # noqa: F401
-)
 from dataretrieval.transport.retry import parse_retry_after as _parse_retry_after
 
 

--- a/dataretrieval/ogc/policy.py
+++ b/dataretrieval/ogc/policy.py
@@ -1,18 +1,34 @@
-"""Low-level OGC policy: dialect types and default endpoint constants.
+"""Low-level OGC policy: dialect, controls, and default endpoint constants.
 
 This module is the single source of truth for the :class:`OgcDialect` type
-(per-API quirks the generic request builder needs) and the default endpoint
-constants used by the Water Data OGC API. It depends only on the stdlib so it
-can be imported safely by any OGC submodule without creating cycles.
+(per-API quirks the generic request builder needs), OGC control validation, and
+the default endpoint constants used by the Water Data OGC API. It depends only
+on the stdlib and the credential-policy leaf, so any OGC submodule can import it
+without creating cycles.
 
 It must NOT import engine, shaping, or any service adapter.
 """
 
 from __future__ import annotations
 
+import numbers
 from dataclasses import dataclass, field
 
 from dataretrieval.credentials import WATERDATA_BASE_URL
+
+
+def _require_positive_int(
+    value: int, name: str, *, examples: str | None = None
+) -> None:
+    """Validate a positive-integer OGC count control.
+
+    Any :class:`numbers.Integral` is accepted, including NumPy and pandas
+    integers, but ``bool`` is rejected despite being an ``Integral`` subtype.
+    """
+    if not isinstance(value, numbers.Integral) or isinstance(value, bool) or value < 1:
+        eg = f", e.g. {examples}" if examples else ""
+        raise ValueError(f"{name} must be a positive integer{eg} (got {value!r}).")
+
 
 # ---------------------------------------------------------------------------
 # Endpoint constants

--- a/dataretrieval/ogc/requests.py
+++ b/dataretrieval/ogc/requests.py
@@ -95,6 +95,31 @@ def _ogc_query_params(
     return params
 
 
+def _partition_request_params(
+    params: dict[str, Any], *, use_cql2: bool
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split URL parameters from multi-value CQL2 POST predicates."""
+    if use_cql2:
+        post_params = {
+            key: value
+            for key, value in params.items()
+            if isinstance(value, (list, tuple)) and len(value) > 1
+        }
+        return (
+            {key: value for key, value in params.items() if key not in post_params},
+            post_params,
+        )
+
+    get_params = {
+        key: ",".join(str(item) for item in value)
+        if isinstance(value, (list, tuple))
+        else value
+        for key, value in params.items()
+        if not (isinstance(value, (list, tuple)) and len(value) == 0)
+    }
+    return get_params, {}
+
+
 def _construct_api_requests(
     service: str,
     properties: list[str] | None = None,
@@ -106,28 +131,15 @@ def _construct_api_requests(
     """Construct an HTTP request object for the specified OGC API service."""
     service_url = f"{_ogc_base_url.get()}/collections/{service}/items"
     dialect = _dialect.get()
-
     for key in _DATE_RANGE_PARAMS:
         if key in kwargs:
             kwargs[key] = _format_api_dates(
                 kwargs[key],
-                date=(service in dialect.date_only_services and key != "last_modified"),
+                date=service in dialect.date_only_services and key != "last_modified",
             )
-
-    if service in dialect.cql2_services:
-        post_params = {
-            k: v
-            for k, v in kwargs.items()
-            if isinstance(v, (list, tuple)) and len(v) > 1
-        }
-        params = {k: v for k, v in kwargs.items() if k not in post_params}
-    else:
-        post_params = {}
-        params = {
-            k: ",".join(str(x) for x in v) if isinstance(v, (list, tuple)) else v
-            for k, v in kwargs.items()
-            if not (isinstance(v, (list, tuple)) and len(v) == 0)
-        }
+    params, post_params = _partition_request_params(
+        kwargs, use_cql2=service in dialect.cql2_services
+    )
 
     _ogc_query_params(
         params,

--- a/dataretrieval/ogc/schema.py
+++ b/dataretrieval/ogc/schema.py
@@ -11,20 +11,20 @@ from typing import Any, cast
 
 import httpx
 
-from dataretrieval.ogc.context import _ogc_base_url
 from dataretrieval.ogc.errors import _raise_for_non_200
+from dataretrieval.ogc.policy import OGC_API_URL
 from dataretrieval.transport.http import HTTPX_DEFAULTS
 from dataretrieval.transport.http import default_headers as _default_headers
 from dataretrieval.transport.http import get as _get
 
 
 def _check_ogc_requests(
-    endpoint: str, req_type: str = "queryables"
+    endpoint: str, req_type: str = "queryables", *, base_url: str = OGC_API_URL
 ) -> tuple[dict[str, Any], httpx.Response]:
     """Retrieve one collection's queryables or response schema."""
     if req_type not in ("queryables", "schema"):
         raise ValueError(f"req_type must be 'queryables' or 'schema', got {req_type!r}")
-    url = f"{_ogc_base_url.get()}/collections/{endpoint}/{req_type}"
+    url = f"{base_url}/collections/{endpoint}/{req_type}"
     response = _get(url, headers=_default_headers(url), **HTTPX_DEFAULTS)
     _raise_for_non_200(response)
     return cast("dict[str, Any]", response.json()), response

--- a/dataretrieval/ogc/shaping.py
+++ b/dataretrieval/ogc/shaping.py
@@ -17,7 +17,7 @@ from typing import Any
 import httpx
 import pandas as pd
 
-from dataretrieval.ogc.policy import DEFAULT_DIALECT, OgcDialect
+from dataretrieval.ogc.policy import DEFAULT_DIALECT, OGC_API_URL, OgcDialect
 from dataretrieval.response_metadata import BaseMetadata
 
 try:
@@ -156,7 +156,11 @@ def _get_resp_data(
 
 
 def _deal_with_empty(
-    return_list: pd.DataFrame, properties: list[str] | None, service: str
+    return_list: pd.DataFrame,
+    properties: list[str] | None,
+    service: str,
+    *,
+    base_url: str = OGC_API_URL,
 ) -> pd.DataFrame:
     """
     Handles empty DataFrame results by returning a DataFrame with appropriate columns.
@@ -174,6 +178,8 @@ def _deal_with_empty(
         List of property names to use as columns, or None.
     service : str
         The service endpoint to query for schema properties if needed.
+    base_url : str, optional
+        OGC API base URL to use for that schema query.
 
     Returns
     -------
@@ -183,10 +189,12 @@ def _deal_with_empty(
     """
     if return_list.empty:
         if not properties or all(pd.isna(properties)):
-            # Import from requests module (no engine dependency).
+            # Schema lookup performs HTTP only for an empty result.
             from dataretrieval.ogc.schema import _check_ogc_requests
 
-            schema, _ = _check_ogc_requests(endpoint=service, req_type="schema")
+            schema, _ = _check_ogc_requests(
+                endpoint=service, req_type="schema", base_url=base_url
+            )
             properties = list(schema.get("properties", {}).keys())
         return pd.DataFrame(columns=properties)
     return return_list
@@ -345,6 +353,7 @@ def _finalize_ogc(
     max_rows: int | None = None,
     extra_id_cols: frozenset[str] | set[str] = frozenset(),
     dialect: OgcDialect | None = None,
+    base_url: str = OGC_API_URL,
 ) -> tuple[pd.DataFrame, BaseMetadata]:
     """Shape a combined OGC result into the user-facing ``(df, md)``.
 
@@ -364,10 +373,12 @@ def _finalize_ogc(
     rather than only per-sub-request, so a chunked call's total is bounded
     to exactly ``max_rows`` and a resumed call honors the cap too. The
     per-``_paginate`` ``_row_cap`` is only an early-stop download bound.
+    ``base_url`` is captured with the finalizer so resumed calls query the same
+    API's schema when their combined result is empty.
     """
     if dialect is None:
         dialect = DEFAULT_DIALECT
-    frame = _deal_with_empty(frame, properties, service)
+    frame = _deal_with_empty(frame, properties, service, base_url=base_url)
     # Normalize to PEP-8 snake_case column names *first*, so the dialect's
     # ``time_cols``/``numerical_cols``/``sort_cols`` (all snake_case) match
     # regardless of whether the API returns snake_case (Water Data, where

--- a/dataretrieval/ogc/shaping.py
+++ b/dataretrieval/ogc/shaping.py
@@ -17,8 +17,8 @@ from typing import Any
 import httpx
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc.policy import DEFAULT_DIALECT, OGC_API_URL, OgcDialect
-from dataretrieval.response_metadata import BaseMetadata
 
 try:
     import geopandas as gpd

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -2,26 +2,24 @@
 
 from __future__ import annotations
 
-import numbers
 import warnings
-from collections.abc import Callable, Iterable, Iterator
-from contextlib import contextmanager
-from contextvars import ContextVar
-from typing import Any, Generic, TypeVar
+from collections.abc import Callable, Iterable
+from typing import Any
 
 import httpx
 import pandas as pd
 
 import dataretrieval.credentials as _credentials
 import dataretrieval.transport.http as _transport_http
+from dataretrieval._ambient import Ambient  # noqa: F401 - compatibility re-export
+from dataretrieval._response_metadata import (
+    BaseMetadata,  # noqa: F401  — compatibility re-export; defined there now
+)
 from dataretrieval.codes import tz
 from dataretrieval.exceptions import (
     NoSitesError,
     URLTooLong,
     error_for_status,
-)
-from dataretrieval.response_metadata import (
-    BaseMetadata,  # noqa: F401  — compatibility re-export; defined there now
 )
 from dataretrieval.transport.retry import (
     _GATEWAY_STATUSES,
@@ -42,70 +40,6 @@ _strip_api_key_from_untrusted_host = _transport_http.strip_api_key_from_untruste
 _strip_api_key_from_untrusted_host_async = (
     _transport_http.strip_api_key_from_untrusted_host_async
 )
-
-_T = TypeVar("_T")
-
-
-class Ambient(Generic[_T]):
-    """A :class:`~contextvars.ContextVar` paired with a scoping contextmanager.
-
-    Bundles the var and its set/reset-token dance into one object, so an ambient
-    value needs a single declaration instead of a ``var`` + setter-function pair.
-    Read the current value with :meth:`get`; set it for a ``with`` block by
-    *calling* the instance — the previous value is restored on exit (and can't
-    leak into a later call the way a hand-written ``try/finally`` can when its
-    ``reset`` is dropped)::
-
-        _base_url = Ambient("ogc_base_url", DEFAULT)
-        with _base_url(other):  # scoped to the block
-            _base_url.get()  # -> other
-    """
-
-    def __init__(self, name: str, default: _T) -> None:
-        self._var: ContextVar[_T] = ContextVar(name, default=default)
-
-    def get(self) -> _T:
-        """The current value — the default outside any active scope."""
-        return self._var.get()
-
-    @contextmanager
-    def __call__(self, value: _T) -> Iterator[None]:
-        """Set the value for the duration of the ``with`` block."""
-        token = self._var.set(value)
-        try:
-            yield
-        finally:
-            self._var.reset(token)
-
-
-def _require_positive_int(
-    value: int, name: str, *, examples: str | None = None
-) -> None:
-    """Validate that ``value`` is a positive integer, else raise ``ValueError``.
-
-    Accepts any :class:`numbers.Integral` (so a numpy/pandas integer passes,
-    not only ``int``) but rejects ``bool`` — an ``Integral`` subtype that is
-    nonsensical as a count. A non-integer (float, str, ``None``) or a value
-    ``< 1`` raises before any I/O, rather than crashing later (e.g. deep in
-    ``pd.DataFrame.head``). Shared by the user-facing count knobs ``max_rows``
-    and ``parallel_chunks(n)`` so their boundary validation can't drift.
-    (``ChunkPlan.max_chunks`` is an internal, already-``int`` precondition with
-    its own domain-specific message, so it keeps a lighter ``< 1`` guard rather
-    than routing through here.)
-
-    Parameters
-    ----------
-    value : int
-        The value to check. Typed ``int`` for callers, but validated at
-        runtime because the real value may be anything the user passed.
-    name : str
-        Parameter name, used as the subject of the error message.
-    examples : str, optional
-        Illustrative values appended to the message (e.g. ``"2, 8, 32"``).
-    """
-    if not isinstance(value, numbers.Integral) or isinstance(value, bool) or value < 1:
-        eg = f", e.g. {examples}" if examples else ""
-        raise ValueError(f"{name} must be a positive integer{eg} (got {value!r}).")
 
 
 def to_str(listlike: object, delimiter: str = ",") -> str | None:

--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -382,45 +382,15 @@ def _get_with_retry(
         raise _url_too_long_error(f"httpx rejected the URL client-side: {exc}") from exc
 
 
-def _query_impl(
+def _query_with_retry(
     url: str,
     payload: dict[str, Any],
     delimiter: str = ",",
     ssl_check: bool = True,
     *,
-    retry_policy: RetryPolicy,
+    retry_policy: RetryPolicy | None = None,
 ) -> httpx.Response:
-    """Send a query.
-
-    Wrapper for ``httpx.get`` that handles errors, converts listed query
-    parameters to comma-separated strings, and returns the response.
-
-    Parameters
-    ----------
-    url: string
-        URL to query.
-    payload: dict
-        Query parameters passed to ``httpx.get``.
-    delimiter: string
-        Delimiter to use with lists.
-    ssl_check: bool
-        Whether to check SSL certificates. Default is True.
-
-    Returns
-    -------
-    response: ``httpx.Response``
-        The response from the API query ``httpx.get`` function call.
-
-    Raises
-    ------
-    DataRetrievalError
-        On an HTTP error response, the typed subclass for the status (see
-        :func:`dataretrieval.exceptions.error_for_status` for the mapping); or
-        :class:`~dataretrieval.exceptions.NoSitesError` when a 200 response
-        reports no data matched; or :class:`~dataretrieval.exceptions.NetworkError`
-        on a connection-level failure (timeout, DNS), with the underlying
-        ``httpx`` exception on ``__cause__``.
-    """
+    """Send an active-service query with bounded transient retry by default."""
 
     for key, value in payload.items():
         payload[key] = to_str(value, delimiter)
@@ -453,29 +423,41 @@ def query(
     delimiter: str = ",",
     ssl_check: bool = True,
 ) -> httpx.Response:
-    return _query_impl(
+    """Send a query.
+
+    Wrapper for ``httpx.get`` that handles errors, converts listed query
+    parameters to comma-separated strings, and returns the response.
+
+    Parameters
+    ----------
+    url: string
+        URL to query.
+    payload: dict
+        Query parameters passed to ``httpx.get``.
+    delimiter: string
+        Delimiter to use with lists.
+    ssl_check: bool
+        Whether to check SSL certificates. Default is True.
+
+    Returns
+    -------
+    response: ``httpx.Response``
+        The response from the API query ``httpx.get`` function call.
+
+    Raises
+    ------
+    DataRetrievalError
+        On an HTTP error response, the typed subclass for the status (see
+        :func:`dataretrieval.exceptions.error_for_status` for the mapping); or
+        :class:`~dataretrieval.exceptions.NoSitesError` when a 200 response
+        reports no data matched; or :class:`~dataretrieval.exceptions.NetworkError`
+        on a connection-level failure (timeout, DNS), with the underlying
+        ``httpx`` exception on ``__cause__``.
+    """
+    return _query_with_retry(
         url,
         payload,
         delimiter,
         ssl_check,
         retry_policy=RetryPolicy(max_retries=0),
-    )
-
-
-query.__doc__ = _query_impl.__doc__
-
-
-def _query_with_retry(
-    url: str,
-    payload: dict[str, Any],
-    delimiter: str = ",",
-    ssl_check: bool = True,
-) -> httpx.Response:
-    """Active-service form of :func:`query` with bounded transient retry."""
-    return _query_impl(
-        url,
-        payload,
-        delimiter,
-        ssl_check,
-        retry_policy=_single_request_policy(),
     )

--- a/dataretrieval/waterdata/cql.py
+++ b/dataretrieval/waterdata/cql.py
@@ -14,13 +14,13 @@ from typing import Any
 
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc import fetch_ogc_request
 from dataretrieval.ogc.requests import (
     _as_str_list,
     _construct_cql_request,
     _switch_properties_id,
 )
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.waterdata.types import (
     WATERDATA_SERVICES,
 )

--- a/dataretrieval/waterdata/measurements.py
+++ b/dataretrieval/waterdata/measurements.py
@@ -12,8 +12,8 @@ from typing import Any
 
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc.filters import FILTER_LANG
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.waterdata.utils import (
     _get_args,
     get_ogc_data,

--- a/dataretrieval/waterdata/metadata.py
+++ b/dataretrieval/waterdata/metadata.py
@@ -13,8 +13,8 @@ from typing import Any
 
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc.filters import FILTER_LANG
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.waterdata.utils import (
     _get_args,
     _with_state,

--- a/dataretrieval/waterdata/nearest.py
+++ b/dataretrieval/waterdata/nearest.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, get_args
 
 import pandas as pd
 
-from dataretrieval.response_metadata import BaseMetadata
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.waterdata.time_series import get_continuous
 
 __all__ = ["get_nearest_continuous"]

--- a/dataretrieval/waterdata/ratings.py
+++ b/dataretrieval/waterdata/ratings.py
@@ -17,7 +17,7 @@ from typing import Any, Literal, get_args
 import httpx
 import pandas as pd
 
-from dataretrieval.credentials import without_embedded_credentials
+from dataretrieval.credentials import WATERDATA_BASE_URL, without_embedded_credentials
 from dataretrieval.exceptions import DataRetrievalError
 from dataretrieval.ogc.dates import _DURATION_RE, _format_api_dates
 from dataretrieval.ogc.errors import _raise_for_non_200
@@ -34,14 +34,12 @@ from dataretrieval.transport.http import (
     get as _get,
 )
 
-from .utils import BASE_URL
-
 __all__ = ["get_ratings"]
 
 
 logger = logging.getLogger(__name__)
 
-STAC_URL = f"{BASE_URL}/stac/v0"
+STAC_URL = f"{WATERDATA_BASE_URL}/stac/v0"
 
 RATING_FILE_TYPE = Literal["exsa", "base", "corr"]
 _VALID_FILE_TYPES = get_args(RATING_FILE_TYPE)

--- a/dataretrieval/waterdata/reference.py
+++ b/dataretrieval/waterdata/reference.py
@@ -12,8 +12,8 @@ from typing import Any, get_args
 
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc.schema import _check_ogc_requests
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.waterdata.types import (
     METADATA_COLLECTIONS,
 )

--- a/dataretrieval/waterdata/samples.py
+++ b/dataretrieval/waterdata/samples.py
@@ -18,8 +18,8 @@ from urllib.parse import quote
 import httpx
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc.errors import _raise_for_non_200
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.transport.http import (
     HTTPX_DEFAULTS,
 )

--- a/dataretrieval/waterdata/stats.py
+++ b/dataretrieval/waterdata/stats.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.credentials import WATERDATA_BASE_URL
 from dataretrieval.ogc.errors import _raise_for_non_200
 from dataretrieval.ogc.shaping import (
@@ -25,7 +26,6 @@ from dataretrieval.ogc.shaping import (
     _attach_coordinates,
     _empty_feature_frame,
 )
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.transport.http import default_headers
 from dataretrieval.transport.pagination import paginate
 from dataretrieval.transport.sync import run_sync

--- a/dataretrieval/waterdata/stats.py
+++ b/dataretrieval/waterdata/stats.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx
 import pandas as pd
 
+from dataretrieval.credentials import WATERDATA_BASE_URL
 from dataretrieval.ogc.errors import _raise_for_non_200
 from dataretrieval.ogc.shaping import (
     _CRS,
@@ -28,7 +29,6 @@ from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.transport.http import default_headers
 from dataretrieval.transport.pagination import paginate
 from dataretrieval.transport.sync import run_sync
-from dataretrieval.waterdata.utils import BASE_URL
 
 __all__ = ["get_data"]
 
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover - exercised only without geopandas
     pass
 
 STATISTICS_API_VERSION = "v0"
-STATISTICS_API_URL = f"{BASE_URL}/statistics/{STATISTICS_API_VERSION}"
+STATISTICS_API_URL = f"{WATERDATA_BASE_URL}/statistics/{STATISTICS_API_VERSION}"
 
 
 def _handle_nesting(

--- a/dataretrieval/waterdata/time_series.py
+++ b/dataretrieval/waterdata/time_series.py
@@ -16,8 +16,8 @@ from typing import Any
 
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.ogc.filters import FILTER_LANG
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.waterdata import stats
 from dataretrieval.waterdata.utils import (
     _get_args,

--- a/dataretrieval/waterdata/utils.py
+++ b/dataretrieval/waterdata/utils.py
@@ -26,11 +26,11 @@ import pandas as pd
 
 import dataretrieval.ogc.dates as _ogc_dates
 import dataretrieval.ogc.shaping as _ogc_shaping
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.codes.states import apply_state
 from dataretrieval.credentials import WATERDATA_BASE_URL
 from dataretrieval.ogc import OgcDialect, prepare_request_args
 from dataretrieval.ogc import get_ogc_data as _facade_get_ogc_data
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.waterdata.types import (
     PROFILE_LOOKUP,
     PROFILES,

--- a/dataretrieval/wateruse.py
+++ b/dataretrieval/wateruse.py
@@ -49,13 +49,13 @@ from typing import Any
 import httpx
 import pandas as pd
 
+from dataretrieval._response_metadata import BaseMetadata
 from dataretrieval.codes.states import to_state
 from dataretrieval.combining import (
     _combine_chunk_frames,
     _combine_chunk_responses,
 )
 from dataretrieval.exceptions import DataRetrievalError
-from dataretrieval.response_metadata import BaseMetadata
 from dataretrieval.transport.http import default_headers, open_async_client
 from dataretrieval.transport.pagination import paginate
 from dataretrieval.transport.retry import RetryPolicy, retry_async

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -621,17 +621,20 @@ def what_activity_metrics(
     return _what("ActivityMetric", ssl_check=ssl_check, legacy=legacy, **kwargs)
 
 
+def _validate_service(service: str, valid_services: list[str], profile: str) -> None:
+    """Validate a service against one WQP profile's supported endpoints."""
+    if service not in valid_services:
+        raise ValueError(
+            f"{profile} service not recognized. Valid options are {valid_services}."
+        )
+
+
 def wqp_url(service: str) -> str:
     """Construct the WQP URL for a given service."""
 
     base_url = "https://www.waterqualitydata.us/data/"
     _warn_legacy_use()
-
-    if service not in services_legacy:
-        raise ValueError(
-            f"Legacy service not recognized. Valid options are {services_legacy}."
-        )
-
+    _validate_service(service, services_legacy, "Legacy")
     return f"{base_url}{service}/Search?"
 
 
@@ -640,12 +643,7 @@ def wqx3_url(service: str) -> str:
 
     base_url = "https://www.waterqualitydata.us/wqx3/"
     _warn_wqx3_use()
-
-    if service not in services_wqx3:
-        raise ValueError(
-            f"WQX3.0 service not recognized. Valid options are {services_wqx3}."
-        )
-
+    _validate_service(service, services_wqx3, "WQX3.0")
     return f"{base_url}{service}/search?"
 
 

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
-from dataretrieval.response_metadata import BaseMetadata
+from dataretrieval._response_metadata import BaseMetadata
 
 from .utils import _attach_datetime_columns, _query_with_retry
 

--- a/docs/source/architecture/decisions/0001-modular-monolith.rst
+++ b/docs/source/architecture/decisions/0001-modular-monolith.rst
@@ -44,7 +44,8 @@ Compliance
 ----------
 
 ``.importlinter`` prevents shared OGC infrastructure from importing service
-adapters, prevents modern modules from depending on legacy NWIS, and requires
-the runtime import graph to stay acyclic; ``lint-imports`` checks it in
-pre-commit and CI. The installed-wheel CI job verifies that the whole monolith
-ships as one usable artifact.
+adapters and prevents modern modules from depending on legacy NWIS;
+``lint-imports`` checks it in pre-commit and CI. A package-wide fitness function
+requires the runtime import graph, including package facades, to stay acyclic.
+The installed-wheel CI job verifies that the whole monolith ships as one usable
+artifact.

--- a/docs/source/architecture/decisions/0003-dependency-direction.rst
+++ b/docs/source/architecture/decisions/0003-dependency-direction.rst
@@ -24,6 +24,8 @@ infrastructure. In particular:
 
 - ``dataretrieval.exceptions`` is a runtime-dependency-light leaf.
 - ``dataretrieval.ogc`` must not import Water Data, NGWMN, Water Use, or NWIS.
+- ``dataretrieval.ogc`` must not depend on the mixed legacy ``utils`` module;
+  shared scoped state lives in a dependency-free leaf instead.
 - Modern modules must not import deprecated NWIS.
 - Service-neutral transport must not import OGC modules or service adapters.
 - Non-OGC services must obtain generic execution behavior from transport, not
@@ -45,26 +47,29 @@ Compliance
 ----------
 
 ``.importlinter`` is the single authority for dependency direction. It declares
-the layer stack, the allowlist of OGC consumers, NGWMN's facade-only seam, the
-NWIS quarantine, collection-family independence, and package-wide acyclicity;
-``lint-imports`` checks all of it against the transitive import graph in
-pre-commit and CI. A boundary that legitimately moves is one edit, in that file,
-alongside the ADR it cites.
+the layer stack, the allowlist of OGC consumers, NGWMN's facade-only seam, OGC's
+independence from legacy utilities, the NWIS quarantine, and collection-family
+independence; ``lint-imports`` checks all of it against the transitive import
+graph in pre-commit and CI. A boundary that legitimately moves is one edit, in
+that file, alongside the ADR it cites.
 
 These rules were previously asserted a second time in
 ``tests/architecture_test.py``, by hand-parsing the AST. That duplication is
-gone. The tests now cover only what an import graph cannot express — which
-symbols cross a seam, what a module's declared exports are, the AST shape of a
-facade, and the one boundary that has to be asserted positively rather than
-forbidden. A new rule that is purely about module-to-module direction belongs in
-``.importlinter``.
+gone. The tests now cover only what the configured contracts cannot express —
+which symbols cross a seam, what a module's declared exports are, the AST shape
+of a facade, boundaries that have to be asserted positively rather than
+forbidden, and full-graph cycle detection. Import Linter's
+``acyclic_siblings`` contract does not detect a cycle between a package facade
+and one of its descendants. A new rule that is purely about module-to-module
+direction belongs in ``.importlinter``.
 
 Named contracts verify the current boundaries: NGWMN's only OGC dependency is
 the facade, ``ogc.shaping`` does not depend on ``ogc.engine``, Water Use and the
-other non-OGC adapters cannot reach the OGC subsystem at all, and the runtime
-graph is acyclic package-wide rather than only within ``ogc`` and ``transport``.
-``waterdata.utils`` not bulk re-exporting private OGC helpers stays in the
-fitness functions, because that claim is about the module's ``__all__``.
+other non-OGC adapters cannot reach the OGC subsystem at all. The fitness
+functions verify that the runtime graph is acyclic package-wide rather than only
+within ``ogc`` and ``transport``. ``waterdata.utils`` not bulk re-exporting
+private OGC helpers stays there too, because that claim is about the module's
+``__all__``.
 
 The OGC consumer list is an allowlist, so a new service module is refused until
 someone places it deliberately. It should shrink as private seams move. Any

--- a/docs/source/architecture/decisions/0006-service-neutral-transport.rst
+++ b/docs/source/architecture/decisions/0006-service-neutral-transport.rst
@@ -101,11 +101,11 @@ Consequences
 Compliance
 ----------
 
-``.importlinter`` enforces transport dependency direction, an acyclic runtime
-graph, and Water Use isolation from OGC. ``tests/architecture_test.py`` covers
-what the import graph cannot see: that presentation and frame-assembly modules
-do not reappear inside transport, and that only ``dataretrieval.credentials``
-names the API-key host. Component and adapter
-tests cover cursor termination, row caps, response aggregation, retry
-exhaustion, ``Retry-After`` limits, the no-progress budget, which failures are
-re-sent, cancellation, no-partial fan-out behavior, and credential host scoping.
+``.importlinter`` enforces transport dependency direction and Water Use
+isolation from OGC. ``tests/architecture_test.py`` covers what the import graph
+cannot see: that presentation and frame-assembly modules do not reappear inside
+transport, and that only ``dataretrieval.credentials`` names the API-key host.
+Component and adapter tests cover cursor termination, row caps, response
+aggregation, retry exhaustion, ``Retry-After`` limits, the no-progress budget,
+which failures are re-sent, cancellation, no-partial fan-out behavior, and
+credential host scoping.

--- a/docs/source/architecture/index.rst
+++ b/docs/source/architecture/index.rst
@@ -100,9 +100,9 @@ Shared components
     Protocol subsystem for Water Data and NGWMN. A small facade
     (``__init__.py``) exposes the service-adapter seam: ``OgcDialect``,
     ``prepare_request_args``, ``get_ogc_data``, and ``fetch_ogc_request``.
-    Internally, ``policy`` defines the dialect type and endpoint constants
-    (depends only on stdlib); ``context`` owns ambient base URL, dialect, and row
-    cap state; ``requests`` owns argument normalization and HTTP request
+    Internally, ``policy`` defines the dialect type, control validation, and
+    endpoint constants; ``context`` owns ambient base URL, dialect, and row cap
+    state; ``requests`` owns argument normalization and HTTP request
     construction; ``schema`` executes queryables/schema requests; ``engine``
     supplies OGC cursor and response strategies to transport pagination;
     ``planning`` determines chunk boundaries; ``chunking`` executes plans and
@@ -110,8 +110,8 @@ Shared components
     contract; ``retry`` classifies failures into OGC interruption types; and
     ``shaping``, ``dates``, ``filters``, and ``errors`` isolate their named
     protocol concerns. The full runtime OGC graph, including the facade, is
-    acyclic — enforced package-wide by the ``acyclic`` contract in
-    ``.importlinter``.
+    acyclic — enforced by the package-wide fitness function in
+    ``tests/architecture_test.py``.
 
 ``dataretrieval.transport``
     Internal service-neutral execution layer. Owns guarded client lifecycle and
@@ -127,18 +127,25 @@ Shared components
     Stable error-policy leaf. It has no runtime third-party dependency, and
     every service can import it without creating an infrastructure cycle.
 
-``dataretrieval.response_metadata``
+``dataretrieval._response_metadata``
     ``BaseMetadata``, the second half of every getter's ``(DataFrame,
     metadata)`` return contract. A dependency-free leaf: nearly every service
     module needs this class, and while it lived in ``utils`` beside the legacy
     query machinery, importing it pulled that module's whole HTTP stack in
-    transitively.
+    transitively. The implementation module is private; the established public
+    class path remains ``dataretrieval.utils.BaseMetadata``.
+
+``dataretrieval._ambient``
+    Dependency-free implementation of scoped context values used by concurrent
+    OGC internals. ``dataretrieval.utils.Ambient`` remains the stable public
+    import and resolves to this same class.
 
 ``dataretrieval.utils``
-    Data-shaping helpers, ambient context support, legacy request composition,
-    and compatibility imports for transport names that historically lived here
-    (including ``BaseMetadata``, so its original import path keeps working). By
-    default, do not add new service-specific behavior there.
+    Data-shaping helpers, legacy request composition, and compatibility imports
+    for names that historically lived here (including ``Ambient`` and
+    ``BaseMetadata``, so their original import paths keep working). OGC does not
+    depend on this mixed legacy module; by default, do not add new
+    service-specific behavior there.
 
 ``dataretrieval.codes`` and ``dataretrieval.rdb``
     State/time-zone code conversion and RDB parsing leaves.
@@ -157,9 +164,9 @@ top-level module fails the contract until it is placed, so where a module
 belongs is decided when it is added rather than inferred later.
 
 ``tests/architecture_test.py`` complements those contracts without repeating
-them. It covers the rules an import graph cannot express — which symbols cross
-a seam, declared ``__all__`` surfaces, the AST shape of a facade, and imports
-that must exist rather than be forbidden.
+their direction rules. It covers which symbols cross a seam, declared
+``__all__`` surfaces, the AST shape of a facade, imports that must exist rather
+than be forbidden, and full-graph cycle detection (see ADR 0003).
 
 Interface view
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ include = ["dataretrieval*"]
 [tool.setuptools.package-data]
 dataretrieval = ["py.typed"]
 
+[tool.complexipy]
+max-complexity-allowed = 25
+failed = true
+
 [project.optional-dependencies]
 # Minimal set the CI ``type-check`` job installs — just mypy + the package,
 # not the whole test stack.
@@ -49,17 +53,17 @@ type-check = [
   "mypy",
 ]
 # Structural gates (complexity ratchets, dependency contracts) and the wily
-# trend history. Pure-Python, so it installs anywhere the package does. Kept out
-# of ``test`` so the test job stays lean; see CONTRIBUTING.md for what each does.
+# trend history. Kept out of ``test`` so the test job stays lean; see
+# CONTRIBUTING.md for what each does.
 metrics = [
   "xenon==0.9.3",
   "wily==1.25.0",
   "complexipy==6.2.0",
   "import-linter==2.13",
 ]
-# Advisory weekly deep sweep -- see .github/workflows/code-health.yml. Separate
-# from ``metrics`` because pyscn is a compiled binary with no linux/aarch64
-# wheel, and the extra the merge gates depend on should stay pure-Python.
+# Advisory weekly deep sweep -- see .github/workflows/code-health.yml. Pyscn has
+# wheels only for macOS ARM64, Linux x86-64, and Windows x86-64, with no sdist,
+# so keep it separate from the extra used by merge gates and contributors.
 health = [
   "pyscn==1.29.0",
 ]

--- a/tests/architecture_test.py
+++ b/tests/architecture_test.py
@@ -33,11 +33,10 @@ from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).parents[1] / "dataretrieval"
 
-#: How many names ``ogc.engine`` may import from ``ogc.requests``. A ceiling
-#: rather than an exact name list: the claim being enforced is "the legacy
-#: compatibility surface does not grow", and a name list also fails on every
-#: rename and every deletion -- neither of which grows anything.
-_MAX_ENGINE_REQUEST_IMPORTS = 14
+#: How many request-building names ``ogc.engine`` currently needs. A ceiling
+#: rather than an exact list allows renames and deletions without weakening the
+#: rule that orchestration must not absorb request construction again.
+_MAX_ENGINE_REQUEST_IMPORTS = 5
 
 
 def _module_name(path: Path) -> str:
@@ -131,12 +130,10 @@ def test_exceptions_has_no_runtime_third_party_dependency() -> None:
 
 
 def test_engine_request_import_surface_does_not_grow() -> None:
-    """Engine may preserve legacy request names but may not grow a new hub.
+    """Engine imports only request names it uses and may not grow a new hub.
 
-    Each name here is either used by engine's own code or re-exported purely so
-    an old import path keeps working. Both are capped: a re-export that nothing
-    imports is dead weight, and a used name past the cap means request
-    construction is migrating back into engine.
+    An import that nothing uses is dead weight, and a used name past the cap
+    means request construction is migrating back into engine.
     """
     path = PACKAGE_ROOT / "ogc" / "engine.py"
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -149,12 +146,19 @@ def test_engine_request_import_surface_does_not_grow() -> None:
     }
     assert len(imported) <= _MAX_ENGINE_REQUEST_IMPORTS, (
         "ogc.engine imports more request names than before; use the canonical "
-        "requests module instead of expanding compatibility exports.\n"
+        "requests module instead of expanding engine's request surface.\n"
         f"limit={_MAX_ENGINE_REQUEST_IMPORTS}\nobserved={sorted(imported)}"
     )
-    # Every imported name must resolve in ``requests``; a stale re-export of a
-    # name that moved or was deleted is an ImportError waiting for the first
-    # caller of the compatibility path.
+    referenced = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+    unused = sorted(imported - referenced)
+    assert not unused, f"ogc.engine has unused request imports: {unused}"
+
+    # Every imported name must resolve in ``requests``; a stale import of a name
+    # that moved or was deleted fails as soon as engine loads.
     from dataretrieval.ogc import requests as ogc_requests
 
     missing = sorted(name for name in imported if not hasattr(ogc_requests, name))

--- a/tests/architecture_test.py
+++ b/tests/architecture_test.py
@@ -1,11 +1,9 @@
-"""Executable fitness functions for architecture rules the import graph cannot
-express.
+"""Executable fitness functions that complement the dependency contracts.
 
-Plain dependency direction -- who may import whom, in which direction, without
-cycles -- is declared in ``.importlinter`` and checked by ``lint-imports`` in
-pre-commit and CI. Those rules used to be asserted here too, and are not any
-more: one rule enforced in two places is one rule that gets updated in one
-place.
+Plain dependency direction -- who may import whom, and in which direction -- is
+declared in ``.importlinter`` and checked by ``lint-imports`` in pre-commit and
+CI. Those rules used to be asserted here too, and are not any more: one rule
+enforced in two places is one rule that gets updated in one place.
 
 What remains is everything a boundary checker cannot see, because an import
 graph has no opinion about it:
@@ -18,7 +16,8 @@ graph has no opinion about it:
 * the AST shape of a module, such as a facade proving it contains no logic, or
   a call proving it passes a destination URL;
 * an import that must *exist*: ``lint-imports`` can forbid an edge, never
-  require one.
+  require one;
+* package-wide acyclicity, including package facades (ADR 0003).
 
 Adding a rule here that is purely about module-to-module direction is a
 regression -- put it in ``.importlinter`` instead.
@@ -27,8 +26,11 @@ regression -- put it in ``.importlinter`` instead.
 from __future__ import annotations
 
 import ast
+import configparser
 import functools
 import sys
+from graphlib import CycleError, TopologicalSorter
+from importlib.util import resolve_name
 from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).parents[1] / "dataretrieval"
@@ -45,6 +47,12 @@ def _module_name(path: Path) -> str:
     if parts[-1] == "__init__":
         parts.pop()
     return ".".join(parts)
+
+
+@functools.cache
+def _package_modules() -> frozenset[str]:
+    """Return every importable module implemented by this package."""
+    return frozenset(_module_name(path) for path in PACKAGE_ROOT.rglob("*.py"))
 
 
 def _is_type_checking(test: ast.expr) -> bool:
@@ -64,15 +72,23 @@ def _is_type_checking(test: ast.expr) -> bool:
 def _resolve_from(current_module: str, path: Path, node: ast.ImportFrom) -> list[str]:
     """Resolve one absolute or relative ``from`` import to module names."""
     if node.level == 0:
-        return [node.module] if node.module else [alias.name for alias in node.names]
+        base_module = node.module or ""
+    else:
+        package = (
+            current_module
+            if path.name == "__init__.py"
+            else current_module.rpartition(".")[0]
+        )
+        base_module = resolve_name("." * node.level + (node.module or ""), package)
 
-    current_parts = current_module.split(".")
-    package_parts = current_parts if path.name == "__init__.py" else current_parts[:-1]
-    ascend = node.level - 1
-    base = package_parts[: len(package_parts) - ascend]
-    if node.module:
-        return [".".join([*base, node.module])]
-    return [".".join([*base, alias.name]) for alias in node.names]
+    dependencies: set[str] = set()
+    for alias in node.names:
+        candidate = ".".join(part for part in (base_module, alias.name) if part)
+        if candidate in _package_modules():
+            dependencies.add(candidate)
+        elif base_module:
+            dependencies.add(base_module)
+    return sorted(dependencies)
 
 
 class _RuntimeImportVisitor(ast.NodeVisitor):
@@ -107,6 +123,15 @@ def _runtime_imports(path: Path) -> set[str]:
     return visitor.modules
 
 
+def _package_import_graph() -> dict[str, set[str]]:
+    """Return runtime edges between modules that belong to this package."""
+    paths = sorted(PACKAGE_ROOT.rglob("*.py"))
+    return {
+        _module_name(path): _runtime_imports(path) & _package_modules()
+        for path in paths
+    }
+
+
 def _literal_exports(path: Path) -> set[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     for node in tree.body:
@@ -127,6 +152,15 @@ def test_exceptions_has_no_runtime_third_party_dependency() -> None:
         "dataretrieval.exceptions gained runtime third-party dependencies: "
         f"{sorted(third_party)}"
     )
+
+
+def test_runtime_import_graph_is_acyclic() -> None:
+    """The complete runtime module graph, including facades, must be a DAG."""
+    try:
+        tuple(TopologicalSorter(_package_import_graph()).static_order())
+    except CycleError as exc:
+        cycle = " -> ".join(exc.args[1])
+        raise AssertionError(f"Runtime import cycle: {cycle}") from exc
 
 
 def test_engine_request_import_surface_does_not_grow() -> None:
@@ -168,6 +202,16 @@ def test_engine_request_import_surface_does_not_grow() -> None:
 
 
 # --- Seams that are about symbols and call sites, not module direction ---
+
+
+def test_ngwmn_uses_ogc_facade() -> None:
+    """NGWMN must retain its positive dependency on the public OGC facade."""
+    ngwmn_imports = _runtime_imports(PACKAGE_ROOT / "ngwmn.py")
+    assert "dataretrieval.ogc" in ngwmn_imports, (
+        "NGWMN must retain its dependency on the OGC facade; internal OGC "
+        "imports are forbidden separately by .importlinter. "
+        f"Found: {sorted(ngwmn_imports)}"
+    )
 
 
 def test_waterdata_utils_is_not_an_ogc_reexport_hub() -> None:
@@ -307,6 +351,22 @@ def test_credential_policy_has_one_definition() -> None:
 
 # --- Adapter structure and public export boundaries ---
 
+
+def _waterdata_family_paths() -> tuple[str, ...]:
+    """Read the collection-family inventory from its dependency contract."""
+    config = configparser.ConfigParser()
+    config.read(PACKAGE_ROOT.parent / ".importlinter")
+    return tuple(
+        module.removeprefix("dataretrieval.").replace(".", "/") + ".py"
+        for module in config["importlinter:contract:waterdata-families"][
+            "modules"
+        ].split()
+    )
+
+
+# The collection-family modules the ``waterdata.api`` facade re-exports.
+_WATERDATA_FAMILIES = _waterdata_family_paths()
+
 #: The modules whose public surface must be declared, not inferred. This is a
 #: list of *files*, not of names: naming the expected exports too would restate
 #: every getter a third time and fail on renames, which break no boundary.
@@ -316,26 +376,11 @@ _EXPLICIT_EXPORT_MODULES = (
     "streamstats.py",
     "wateruse.py",
     "wqp.py",
-    "waterdata/cql.py",
-    "waterdata/measurements.py",
-    "waterdata/metadata.py",
     "waterdata/nearest.py",
     "waterdata/ratings.py",
-    "waterdata/reference.py",
-    "waterdata/samples.py",
     "waterdata/stats.py",
-    "waterdata/time_series.py",
     "waterdata/types.py",
-)
-
-# The collection-family modules the ``waterdata.api`` facade re-exports.
-_WATERDATA_FAMILIES = (
-    "waterdata/time_series.py",
-    "waterdata/metadata.py",
-    "waterdata/measurements.py",
-    "waterdata/reference.py",
-    "waterdata/samples.py",
-    "waterdata/cql.py",
+    *_WATERDATA_FAMILIES,
 )
 
 

--- a/tests/nldi_test.py
+++ b/tests/nldi_test.py
@@ -184,6 +184,48 @@ def test_get_features_by_lat_long(httpx_mock):
     assert gdf.size == 6
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"lat": 43.087}, "Both lat and long are required"),
+        (
+            {"lat": 43.087, "long": -89.509, "comid": 13294314},
+            "comid cannot be provided with lat or long",
+        ),
+        (
+            {"lat": 43.087, "long": -89.509, "feature_source": "WQP"},
+            "feature_source and feature_id cannot be provided with lat or long",
+        ),
+        ({"comid": 13294314}, "navigation_mode is required"),
+    ],
+)
+def test_get_features_rejects_ambiguous_origins(kwargs, message):
+    """Origin validation remains ahead of request execution after extraction."""
+    with pytest.raises(ValueError, match=message):
+        get_features(**kwargs)
+
+
+def test_get_features_includes_stop_comid(httpx_mock):
+    """The extracted request builder preserves optional navigation bounds."""
+    request_url = (
+        f"{NLDI_API_BASE_URL}/comid/13294314/navigation/UM/WQP"
+        "?distance=5&stopComid=13294315"
+    )
+    mock_request_data_sources(httpx_mock)
+    mock_request(httpx_mock, request_url, "tests/data/nldi_get_features_by_comid.json")
+
+    result = get_features(
+        comid=13294314,
+        data_source="WQP",
+        navigation_mode="UM",
+        distance=5,
+        stop_comid=13294315,
+        as_json=True,
+    )
+
+    assert isinstance(result, dict)
+
+
 def test_search_for_basin(httpx_mock):
     """Tests NLDI search query for basin"""
     request_url = (

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -8,6 +8,23 @@ import pytest
 from dataretrieval import exceptions, nwis, utils
 
 
+class Test_Ambient:
+    def test_implementation_keeps_documented_public_identity(self):
+        from dataretrieval._ambient import Ambient
+
+        assert utils.Ambient is Ambient
+        assert Ambient.__module__ == "dataretrieval.utils"
+
+    def test_scope_restores_previous_value(self):
+        value = utils.Ambient("test_ambient", "default")
+
+        with value("outer"):
+            with value("inner"):
+                assert value.get() == "inner"
+            assert value.get() == "outer"
+        assert value.get() == "default"
+
+
 class Test_query:
     """Tests of the query function (mocked — no live NWIS calls)."""
 
@@ -282,6 +299,23 @@ class Test_BaseMetadata:
         # site_info is abstract on BaseMetadata; only nwis/wqp implement it.
         with pytest.raises(NotImplementedError):
             _ = md.site_info
+
+    def test_pickle_keeps_historical_import_path(self):
+        """New pickles remain readable by releases predating the class move."""
+        import pickle
+
+        from dataretrieval._response_metadata import BaseMetadata
+
+        md = BaseMetadata.__new__(BaseMetadata)
+        md.url = "https://example.test"
+        md.query_time = None
+        md.header = {}
+        md.comment = None
+
+        payload = pickle.dumps(md)
+
+        assert b"dataretrieval.utils" in payload
+        assert pickle.loads(payload).__class__ is BaseMetadata
 
 
 class Test_to_str:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -33,6 +33,33 @@ class Test_query:
         assert response.status_code == 200  # GET was successful
         assert "user-agent" in response.request.headers
 
+    def test_no_sites_detection_respects_response_charset(self, httpx_mock):
+        """The legacy sentinel is checked after HTTP charset decoding."""
+        url = "https://example.invalid/x"
+        body = "No sites/data found".encode("utf-16")
+        httpx_mock.add_response(
+            method="GET",
+            url=url,
+            content=body,
+            headers={"Content-Type": "text/plain; charset=utf-16"},
+        )
+
+        with pytest.raises(exceptions.NoSitesError):
+            utils.query(url, {})
+
+    def test_query_does_not_opt_into_retry(self, httpx_mock, monkeypatch):
+        """The public legacy adapter still surfaces the first transient failure."""
+        url = "https://example.invalid/x"
+        request_url = f"{url}?a=1"
+        httpx_mock.add_response(method="GET", url=request_url, status_code=503)
+        httpx_mock.add_response(method="GET", url=request_url, text="unexpected retry")
+        monkeypatch.setenv("API_USGS_RETRIES", "1")
+
+        with pytest.raises(exceptions.ServiceUnavailable):
+            utils.query(url, {"a": "1"})
+
+        assert len(httpx_mock.get_requests()) == 1
+
     def test_opt_in_retry_recovers_from_transient(self, httpx_mock, monkeypatch):
         """Active adapters can opt into bounded retry without changing NWIS."""
         import dataretrieval.transport.retry as retry

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -119,6 +119,50 @@ def test_get_results_WQX3(httpx_mock):
     assert df["Activity_StartDateTime"].notna().all()
 
 
+@pytest.mark.parametrize(
+    ("builder", "service", "expected", "warning"),
+    [
+        (
+            wqp.wqp_url,
+            "Result",
+            "https://www.waterqualitydata.us/data/Result/Search?",
+            DeprecationWarning,
+        ),
+        (
+            wqp.wqx3_url,
+            "Result",
+            "https://www.waterqualitydata.us/wqx3/Result/search?",
+            UserWarning,
+        ),
+    ],
+)
+def test_wqp_url_profiles(builder, service, expected, warning):
+    """Each profile keeps its warning policy and exact endpoint casing."""
+    with pytest.warns(warning):
+        assert builder(service) == expected
+
+
+@pytest.mark.parametrize(
+    ("builder", "profile", "valid_services", "warning"),
+    [
+        (wqp.wqp_url, "Legacy", wqp.services_legacy, DeprecationWarning),
+        (wqp.wqx3_url, "WQX3.0", wqp.services_wqx3, UserWarning),
+    ],
+)
+def test_wqp_url_profiles_reject_unknown_service(
+    builder, profile, valid_services, warning
+):
+    """Shared validation preserves profile-specific error text and ordering."""
+    with pytest.warns(warning):
+        with pytest.raises(
+            ValueError,
+            match=rf"^{profile} service not recognized\. Valid options are ",
+        ) as exc_info:
+            builder("unknown")
+
+    assert str(valid_services) in str(exc_info.value)
+
+
 # Every WQP ``what_*`` wrapper issues the same query against its own service
 # endpoint and returns the parsed DataFrame + metadata; they differ only by the
 # service path segment and the response fixture. Each case names one column that


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #360. This branch starts at #360's current head (`1f2ca335`). GitHub cannot use a fork-owned head branch as the base ref of an upstream PR, so the diff includes #360 until that PR merges; afterward it collapses to the follow-up commits.

## Review findings addressed

- Replace the root `acyclic_siblings` contract, which cannot detect facade-to-descendant cycles, with one package-wide runtime-import fitness test. Keep `.importlinter` as the sole owner of dependency direction.
- Restore the positive NGWMN-to-OGC-facade assertion and derive the Water Data facade-family inventory from its independence contract.
- Capture pyscn's human summary from stderr, publish a real empty-output fallback, and attach the sanity record to the artifact.
- Preserve `BaseMetadata`'s historical pickle identity so objects created after #360 remain readable by older releases.
- Correct the documented platform limits for the compiled health and metrics tools.
- Point the standalone Ratings and Statistics clients at the canonical credentials leaf instead of reaching through the Water Data OGC adapter for its base-URL alias.
- Capture the OGC schema endpoint explicitly in result finalizers instead of reading ambient request context during empty-result shaping.
- Remove OGC's dependency on the mixed legacy `utils` module while preserving the documented `dataretrieval.utils.Ambient` class identity.

## Health movement over #360

| Measure | #360 | This branch |
|---|---:|---:|
| `nldi.get_features` cognitive complexity | 27 | 1 |
| extracted NLDI request router | - | 15 |
| `_construct_api_requests` cognitive / cyclomatic | 25 / 17 | 5 / 6 |
| extracted request partitioner cognitive / cyclomatic | - | 16 / 12 |
| package cognitive ratchet | 27 | 25 |
| pyscn duplicated fragments | 11.4% / 8 groups | 9.4% / 5 groups |
| pyscn duplication subscore | 60 | 70 |
| pyscn internal dependencies / max depth | 144 / 11 | 143 / 9 |
| pyscn dependency subscore | 70 | 75 |
| pyscn architecture subscore | 81 | 85 |
| pyscn high-risk rows | 19 | 18 |
| pyscn composite | 78 | 81 |
| pyscn grade | B | B |

The duplication gain removes a private pass-through query function and its import-time docstring assignment and shares WQP profile validation. Partial frame and response assembly now have separate paths, so inspecting one no longer computes and discards the other. Public signatures, documentation, warning policies, endpoint casing, error text, and retry behavior remain unchanged. The remaining clone groups are documented collection wrappers with explicit typed signatures, so this stops before weakening public getters merely to optimize the score.

The architecture gains remove two dependencies on the OGC adapter from clients for separate Water Data protocols, then remove OGC's three dependencies on the mixed top-level `utils` module. Scoped context now lives in a stdlib-only leaf, OGC count validation lives with OGC policy, and an Import Linter contract prevents that legacy dependency from returning. The historical `utils.Ambient` import remains the same class object. Pyscn's only error-level hub finding is demoted to a warning; weighted architecture violations fall from 38 to 30. Stable leaves and intentional facades remain untouched despite pyscn's remaining warnings.

The dependency gain passes each API's base URL into the finalizer that may fetch an empty result's schema. That replaces `ogc.schema -> ogc.context` with a direct dependency on the OGC policy leaf, shortens the maximum path from 10 to 9 (11 on #360), and makes resumed/custom-API calls independent of restored ambient context. Existing NGWMN empty-result coverage verifies that custom schema requests still target the NGWMN endpoint.

A four-angle cleanup pass removed another 38 net lines: retry defaults and the Complexipy threshold each have one owner; package cycles use the standard-library topological sorter; import resolution uses `importlib`; and repeated cycle-policy rationale now lives in ADR 0003. A final boundary pass also deletes unused private request re-exports from `ogc.engine` and a dead pagination alias from `ogc.errors` rather than preserving compatibility paths with no consumers.

The 25 cognitive ceiling is the tightest package-wide threshold: 24 fails only on deprecated `nwis._read_json`. Pyscn's separate Complexity score remains 95: its one penalty is based on aggregate McCabe complexity across 345 rows and requires a 50-point reduction to reach the next attainable score, 100. The few clear local simplifications do not approach that boundary, so this avoids broad extraction or trivial-function dilution solely for the metric.

## Verification

- `coverage run -m pytest tests/ && coverage report -m`: 767 passed, 12 deselected, 97%
- `pytest tests/ -m live -v --reruns 2 --reruns-delay 5`: 12 passed
- `pre-commit run --all-files`: all hooks pass
- `mypy`: clean across 52 source files
- `python -m build`: sdist and wheel built; `_ambient.py` and `_response_metadata.py` are present in both artifacts
- architecture/reference Sphinx build: succeeds (expected excluded-example and existing duplicate-doc warnings)
- upstream Sphinx checks: pass on the current commit
- differential probes: 17,280 NLDI argument combinations and 231 OGC request cases match #360
- cross-version pickle probe: child-created `BaseMetadata` loads under pre-move commit 2134eeaa
- `Ambient` compatibility probe: implementation and documented v1.2.0 import are the same class object
- adversarial cycle probes: absolute/relative sibling and facade cycles fail; current import spellings pass
- retry regression: active adapters recover from a transient response while public legacy `query` sends exactly once
- legacy no-sites regression: charset-aware sentinel detection remains unchanged
- WQP regressions: both profiles preserve exact URLs, warning categories, validation messages, and valid-service ordering
