### PR TITLE
fix(demos): plot the unit-values time series off a plain frame

### DIFF
--- a/demos/hydroshare/USGS_WaterData_UnitValues_Examples.ipynb
+++ b/demos/hydroshare/USGS_WaterData_UnitValues_Examples.ipynb
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = discharge[0].plot(x=\"time\", y=\"value\", style=\".\")\n",
+    "ax = discharge[0][[\"time\", \"value\"]].plot(x=\"time\", y=\"value\", style=\".\")\n",
     "ax.set_xlabel(\"Date\")\n",
     "ax.set_ylabel(\"Streamflow (cfs)\")"
    ]


### PR DESCRIPTION
## What

One line in `demos/hydroshare/USGS_WaterData_UnitValues_Examples.ipynb`:

```diff
-ax = discharge[0].plot(x="time", y="value", style=".")
+ax = discharge[0][["time", "value"]].plot(x="time", y="value", style=".")
```

## Why

The cell raised `TypeError: Axes.scatter() got multiple values for argument 'x'`. Because `conf.py` sets `nbsphinx_allow_errors = True`, this did **not** fail the docs build — it rendered the traceback on the published example page instead, which is why it went unnoticed.

`waterdata.get_continuous` returns a `GeoDataFrame`, and `GeoDataFrame.plot()` dispatches to the *geospatial* plot unless a pandas `kind` is given. So `x="time"` was carried through as a style keyword down into `ax.scatter(x, y, **kwargs)`, which already had `x` positionally.

Subsetting to the two plotted columns yields a plain `DataFrame` and therefore the pandas plot. That is exactly what the two sibling notebooks doing the same time-series plot already do:

```python
dailyStreamflow[0][["time", "value"]].plot(x="time", y="value")          # DailyValues
data[0][["time", "value"]].plot(x="time", y="value", style=".")          # GroundwaterLevels
discharge[0].plot(x="time", y="value", style=".")                        # UnitValues — the only one missing it
```

So this restores the established convention rather than introducing a new one. (`kind="line"` also fixes it, but would make this notebook the odd one out.)

## Testing

All 23 tracked notebooks were executed against the live APIs. Result: **21 passed, 2 failed.**

- This one — fixed here, and re-verified by executing the notebook end to end afterwards.
- `demos/R Python Vignette equivalents.ipynb` — **not a code defect.** It fails on `waterqualitydata.us` with `SSL: CERTIFICATE_VERIFY_FAILED … self-signed certificate in certificate chain`, an artifact of a TLS-intercepting proxy on the machine that ran it. `api.waterdata.usgs.gov` was reachable in the same run. Nothing to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTaSm7HmVb94RSJiKW4WAS
