### PR TITLE
Refactor OGC and fan-out internals

### DIFF
--- a/dataretrieval/ogc/dates.py
+++ b/dataretrieval/ogc/dates.py
@@ -164,3 +164,14 @@ def _format_api_dates(
             return None
         formatted.append(one)
     return "/".join(formatted)
+
+
+def _format_date_params(
+    params: dict[str, str | Sequence[str | None] | None], *, date_only: bool
+) -> None:
+    """Format every date-shaped OGC parameter in ``params`` in place."""
+    for key in _DATE_RANGE_PARAMS:
+        if key in params:
+            params[key] = _format_api_dates(
+                params[key], date=date_only and key != "last_modified"
+            )

--- a/dataretrieval/ogc/filters.py
+++ b/dataretrieval/ogc/filters.py
@@ -90,6 +90,17 @@ def _resume_after_or(expr: str, i: int) -> int | None:
     return _skip_space(expr, after_word)
 
 
+def _advance_structure(
+    ch: str, in_quote: str | None, depth: int
+) -> tuple[str | None, int]:
+    """Advance quote and parenthesis state by one CQL character."""
+    if in_quote is not None:
+        return (None if ch == in_quote else in_quote), depth
+    if ch in ("'", '"'):
+        return ch, depth
+    return None, depth + {"(": 1, ")": -1}.get(ch, 0)
+
+
 def _split_top_level_or(expr: str) -> list[str]:
     """Split ``expr`` at each top-level ``OR``, respecting quotes and parens.
 
@@ -102,27 +113,18 @@ def _split_top_level_or(expr: str) -> list[str]:
     depth = 0
     in_quote: str | None = None
     i = 0
-    n = len(expr)
-    while i < n:
+    while i < len(expr):
         ch = expr[i]
-        if in_quote is not None:
-            if ch == in_quote:
-                in_quote = None
-        elif ch in ("'", '"'):
-            in_quote = ch
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        elif depth == 0 and ch.isspace():
+        if in_quote is None and depth == 0 and ch.isspace():
             resume = _resume_after_or(expr, i + 1)
             if resume is not None:
                 parts.append(expr[last:i].strip())
                 last = i = resume
                 continue
+        in_quote, depth = _advance_structure(ch, in_quote, depth)
         i += 1
     parts.append(expr[last:].strip())
-    return [p for p in parts if p]
+    return [part for part in parts if part]
 
 
 def _check_numeric_filter_pitfall(filter_expr: str) -> None:

--- a/dataretrieval/ogc/planning.py
+++ b/dataretrieval/ogc/planning.py
@@ -255,6 +255,26 @@ def _split_at(chunks: list[list[str]], idx: int) -> None:
     chunks[idx : idx + 1] = [chunk[:mid], chunk[mid:]]
 
 
+def _largest_splittable_chunk(
+    axes: list[_Axis],
+    chunks: dict[str, list[list[str]]],
+    *,
+    total: int,
+    max_chunks: int,
+) -> tuple[_Axis, int] | None:
+    """Select the largest chunk whose axis can split within the cap."""
+    candidate: tuple[_Axis, int] | None = None
+    candidate_size = -1
+    for axis in axes:
+        axis_chunks = chunks[axis.arg_key]
+        if total + total // len(axis_chunks) > max_chunks:
+            continue
+        for idx, chunk in enumerate(axis_chunks):
+            if len(chunk) > 1 and len(chunk) > candidate_size:
+                candidate, candidate_size = (axis, idx), len(chunk)
+    return candidate
+
+
 class ChunkPlan:
     """
     Strategy for issuing one user-level request as URL-fitting chunks.
@@ -506,17 +526,12 @@ class ChunkPlan:
             # work across chunks rather than fitting a byte budget. A
             # chunk of size 1 can't be split further. Stable input order breaks
             # ties by axis order, then lowest index within an axis.
-            candidate: tuple[_Axis, int] | None = None
-            candidate_size = -1
-            for axis in self.axes:
-                axis_chunks = self.chunks[axis.arg_key]
-                if total + total // len(axis_chunks) > max_chunks:
-                    continue  # any split of this axis would overshoot the cap
-                for idx, chunk in enumerate(axis_chunks):
-                    if len(chunk) <= 1:
-                        continue
-                    if len(chunk) > candidate_size:
-                        candidate, candidate_size = (axis, idx), len(chunk)
+            candidate = _largest_splittable_chunk(
+                self.axes,
+                self.chunks,
+                total=total,
+                max_chunks=max_chunks,
+            )
             if candidate is None:
                 # Every axis is saturated at one atom per chunk or would
                 # overshoot the cap; stop below it rather than exceed it.

--- a/dataretrieval/ogc/requests.py
+++ b/dataretrieval/ogc/requests.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import httpx
 
-from dataretrieval.ogc.dates import _DATE_RANGE_PARAMS, _format_api_dates
+from dataretrieval.ogc.dates import _DATE_RANGE_PARAMS, _format_date_params
 from dataretrieval.ogc.policy import DEFAULT_DIALECT, OgcDialect
 from dataretrieval.transport.http import default_headers as _default_headers
 
@@ -160,14 +160,7 @@ def _construct_api_requests(
     service_url = _items_url(collection, base_url)
     if dialect is None:
         dialect = DEFAULT_DIALECT
-    for key in _DATE_RANGE_PARAMS:
-        if key in kwargs:
-            kwargs[key] = _format_api_dates(
-                kwargs[key],
-                date=(
-                    collection in dialect.date_only_services and key != "last_modified"
-                ),
-            )
+    _format_date_params(kwargs, date_only=collection in dialect.date_only_services)
     params, post_params = _partition_request_params(
         kwargs, use_cql2=collection in dialect.cql2_services
     )
@@ -292,6 +285,23 @@ def _check_monitoring_location_id(
     return value
 
 
+def _normalize_request_arg(name: str, value: Any, no_normalize: frozenset[str]) -> Any:
+    """Apply the OGC normalization rule for one included getter argument."""
+    if name == "monitoring_location_id":
+        return _check_monitoring_location_id(value)
+    if name == "properties":
+        return _as_str_list(value, name)
+    if (
+        name in no_normalize
+        and isinstance(value, Iterable)
+        and not isinstance(value, str)
+    ):
+        return value.tolist() if hasattr(value, "tolist") else list(value)
+    if isinstance(value, str) or not isinstance(value, Iterable):
+        return value
+    return _normalize_str_iterable(value, name)
+
+
 def prepare_request_args(
     local_vars: dict[str, Any],
     exclude: set[str] | None = None,
@@ -318,17 +328,8 @@ def prepare_request_args(
         to_exclude.update(exclude)
 
     args: dict[str, Any] = {}
-    for k, v in local_vars.items():
-        if k in to_exclude or v is None:
+    for name, value in local_vars.items():
+        if name in to_exclude or value is None:
             continue
-        if k == "monitoring_location_id":
-            args[k] = _check_monitoring_location_id(v)
-        elif k == "properties":
-            args[k] = _as_str_list(v, k)
-        elif k in no_normalize and isinstance(v, Iterable) and not isinstance(v, str):
-            args[k] = v.tolist() if hasattr(v, "tolist") else list(v)
-        elif isinstance(v, str) or not isinstance(v, Iterable):
-            args[k] = v
-        else:
-            args[k] = _normalize_str_iterable(v, k)
+        args[name] = _normalize_request_arg(name, value, no_normalize)
     return args

--- a/dataretrieval/transport/fanout.py
+++ b/dataretrieval/transport/fanout.py
@@ -666,30 +666,33 @@ class FanOut(Generic[_Chunk]):
                     return_exceptions=True,
                 )
                 failures = [r for r in results if isinstance(r, BaseException)]
-                for exc in failures:
-                    if not isinstance(exc, Exception):
-                        raise exc
-                # Classify first, build once. Every failure has to be
-                # examined -- a non-transient sibling must surface raw -- but
-                # only the first transient is ever raised. Asking
-                # ``wrap_failure`` per failure would snapshot the combined
-                # frame N times (a full concat over every completed
-                # chunk) and discard all but one, which a batch of
-                # chunks failing together makes routine.
-                first_transient: BaseException | None = None
-                for exc in failures:
-                    if _classify_chunk_error(exc) is None:
-                        raise self._normalize_failure(exc)
-                    if first_transient is None:
-                        first_transient = exc
-                if first_transient is not None:
-                    interrupted = self.wrap_failure(first_transient)
-                    if interrupted is None:
-                        # Unreachable: classified as transient just above.
-                        raise self._normalize_failure(first_transient)
-                    raise interrupted from first_transient
+                self._raise_failures(failures)
 
         return self.finalize(*self._combine_raw())
+
+    def _raise_failures(self, failures: list[BaseException]) -> None:
+        """Raise failures according to fan-out's precedence rules."""
+        for exc in failures:
+            if not isinstance(exc, Exception):
+                raise exc
+        # Classify first, build once. Every failure has to be examined -- a
+        # non-transient sibling must surface raw -- but only the first transient
+        # is ever raised. Asking ``wrap_failure`` per failure would snapshot the
+        # combined frame N times (a full concat over every completed chunk) and
+        # discard all but one, which a batch of chunks failing together makes
+        # routine.
+        first_transient: BaseException | None = None
+        for exc in failures:
+            if _classify_chunk_error(exc) is None:
+                raise self._normalize_failure(exc)
+            if first_transient is None:
+                first_transient = exc
+        if first_transient is not None:
+            interrupted = self.wrap_failure(first_transient)
+            if interrupted is None:
+                # Unreachable: classified as transient just above.
+                raise self._normalize_failure(first_transient)
+            raise interrupted from first_transient
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

This PR applies exactly five metric-gated architecture refactors to the OGC and fan-out internals. All five were retained because each reduced meaningful local and package complexity, preserved behavior, kept every coarse PySCN score non-regressing, introduced no clone group, and kept all dependency contracts intact.

The work is based on `upstream/main` at `c3242789` and is independent of draft PR #353. It changes no public interface or import path.

## Recent PySCN history

I measured the last 15 first-parent commits with the same PySCN version and verified project-root resolution for every report.

- PR #355 (`702c6ad9`) temporarily lowered health **81→80** and cohesion **100→95**.
- PR #364 (`3474c3cc`) recovered health **80→82**, cohesion **95→100**, dependency score **75→80**, and depth **9→8**.
- PR #368 (`0ff534c2`) lowered architecture **87→82** without changing overall health; PR #369 restored architecture to **87**.
- PR #375 (`ed307b7d`) moved architecture **87→84**, again without changing health.
- PR #372 (`ced0d1ea`) moved duplication **8.7%→9.5%** and clone groups **5→6** while health remained 82.
- PR #373 (`c3242789`) made no PySCN change.

The sixth clone group after #372 is Type-4 semantic similarity between `wqp.get_results` and `wqp._what`. Those functions have distinct service behavior, so this PR intentionally does not collapse it. It likewise does not optimize intentional collection-family getter resemblance or treat Python leaf modules in a reported “zone of pain” as defects.

## Five measured iterations

| # | Internal seam | Decision | Local evidence |
|---|---|---|---|
| 1 | `FanOut._raise_failures` | Retain | `_run`: CC **11→4**, cognitive **33→8**, nesting **4→3**; high-risk functions **21→20** |
| 2 | `_advance_structure` | Retain | `_split_top_level_or`: CC **11→6**, cognitive **15→8**, nesting **7→3** |
| 3 | `_format_date_params` | Retain | `_construct_api_requests`: CC **6→4**, cognitive **7→3**, nesting **2→1** |
| 4 | `_normalize_request_arg` | Retain | `prepare_request_args`: CC **8→4**, cognitive **17→6**, nesting **5→2** |
| 5 | `_largest_splittable_chunk` | Retain | `ChunkPlan._refine`: CC **10→5**, cognitive **24→6**, nesting **4→2** |

No experiment was reverted: every candidate met the retain gate. Iteration 4 briefly moved duplication from 9.4737% to 9.5070% without adding a group; iteration 5 returned it to baseline.

## Updated PySCN scores

| Metric | Baseline | Final |
|---|---:|---:|
| Health / grade | 82 / B | 82 / B |
| Complexity score | 95 | 95 |
| High-risk functions | 21 | **20** |
| Average cyclomatic complexity | 2.362903 | **2.334218** |
| Average cognitive complexity | 5.793011 | **5.564987** |
| Dead-code score / issues | 100 / 0 | 100 / 0 |
| Duplication score | 70 | 70 |
| Duplicated fragments | 9.4737% | 9.4737% |
| Clone groups | 6 | 6 |
| Coupling | 100 | 100 |
| Cohesion | 100 | 100 |
| Dependencies / depth | 80 / 8 | 80 / 8 |
| Architecture | 84 | 84 |

Architecture-metrics corroborates the local trend: maintainability index improved in all five touched modules, max CC fell in `filters` **12→10**, `requests` **13→12**, and `fanout` **13→8**, and every touched module retained identical afferent/efferent coupling. `FanOut` LCOM96b moved slightly **0.840→0.856** when failure precedence became a named method; this is treated as a holistic trend rather than outweighing the method's large local complexity reduction, stable PySCN cohesion, unchanged coupling, and clearer ADR-0008 policy seam.

## Architecture

- Date-shaped parameter ownership now stays in `ogc.dates`.
- CQL structure-state transitions stay behind a private filter-parser seam.
- Request normalization separates argument selection from one-argument interpretation.
- Chunk refinement separates pure split selection from plan mutation.
- Fan-out failure precedence remains inside `FanOut` and preserves ADR 0008 behavior.
- No new module, dependency edge, public symbol, or external dependency was added.
- All seven ADR-backed import-linter contracts remain intact.

An independent Standards/Spec review found no hard or spec findings. It noted one mild same-module Feature Envy judgment call for `_largest_splittable_chunk`; no action was recommended because the selector is pure, private, and local to the planning module.

## Validation

- `pytest -q tests -k 'not test_nwis_service_live'`: **813 passed, 12 deselected**, 57 expected warnings
- Focused iteration suites: **140**, **196**, **280**, **187**, and **216** tests passed respectively
- `ruff format --check .`
- `ruff check .`
- `mypy --strict dataretrieval`: all **58** source files passed
- Xenon thresholds passed
- complexipy threshold passed
- `lint-imports`: **7 kept, 0 broken**
- `git diff --check`
