### PR TITLE
Fix WQX3 array parameter serialization

### DIFF
--- a/dataretrieval/_querying.py
+++ b/dataretrieval/_querying.py
@@ -171,6 +171,16 @@ def _get_with_retry(
         raise _url_too_long_error(f"httpx rejected the URL client-side: {exc}") from exc
 
 
+def _materialize_query_iterables(payload: dict[str, Any]) -> dict[str, Any]:
+    """Copy a query payload, materializing non-string iterables as lists."""
+    return {
+        key: list(value)
+        if isinstance(value, Iterable) and not isinstance(value, (str, list))
+        else value
+        for key, value in payload.items()
+    }
+
+
 def _query_with_retry(
     url: str,
     payload: dict[str, Any],
@@ -182,14 +192,16 @@ def _query_with_retry(
 ) -> httpx.Response:
     """Send an active-service query with bounded transient retry by default.
 
-    When ``delimiter`` is ``None``, iterable values pass through for ``httpx``
-    to encode as repeated query parameters.
+    When ``delimiter`` is ``None``, iterable values are materialized for
+    ``httpx`` to encode as repeated query parameters. Strings remain scalar.
     """
 
-    if delimiter is not None:
-        payload = {k: to_str(v, delimiter) for k, v in payload.items()}
+    if delimiter is None:
+        payload = _materialize_query_iterables(payload)
+    else:
+        payload = {key: to_str(value, delimiter) for key, value in payload.items()}
     # httpx serializes None params as ``foo=``; USGS rejects with 400. Drop them.
-    payload = {k: v for k, v in payload.items() if v is not None}
+    payload = {key: value for key, value in payload.items() if value is not None}
 
     user_agent = {"user-agent": USER_AGENT}
 

--- a/dataretrieval/_querying.py
+++ b/dataretrieval/_querying.py
@@ -187,11 +187,8 @@ def _query_with_retry(
     """
 
     if delimiter is not None:
-        for key, value in payload.items():
-            payload[key] = to_str(value, delimiter)
-    # httpx serializes None params as ``foo=``; USGS rejects with 400.
-    # Drop them. (With a delimiter, ``to_str`` also returns None for
-    # non-iterable scalars like bools.)
+        payload = {k: to_str(v, delimiter) for k, v in payload.items()}
+    # httpx serializes None params as ``foo=``; USGS rejects with 400. Drop them.
     payload = {k: v for k, v in payload.items() if v is not None}
 
     user_agent = {"user-agent": USER_AGENT}

--- a/dataretrieval/_querying.py
+++ b/dataretrieval/_querying.py
@@ -174,18 +174,24 @@ def _get_with_retry(
 def _query_with_retry(
     url: str,
     payload: dict[str, Any],
-    delimiter: str = ",",
+    delimiter: str | None = ",",
     ssl_check: bool = True,
     *,
     retry_policy: RetryPolicy | None = None,
     adapter: str | None = None,
 ) -> httpx.Response:
-    """Send an active-service query with bounded transient retry by default."""
+    """Send an active-service query with bounded transient retry by default.
 
-    for key, value in payload.items():
-        payload[key] = to_str(value, delimiter)
+    When ``delimiter`` is ``None``, iterable values pass through for ``httpx``
+    to encode as repeated query parameters.
+    """
+
+    if delimiter is not None:
+        for key, value in payload.items():
+            payload[key] = to_str(value, delimiter)
     # httpx serializes None params as ``foo=``; USGS rejects with 400.
-    # Drop them. (``to_str`` returns None for non-iterable scalars like bools.)
+    # Drop them. (With a delimiter, ``to_str`` also returns None for
+    # non-iterable scalars like bools.)
     payload = {k: v for k, v in payload.items() if v is not None}
 
     user_agent = {"user-agent": USER_AGENT}

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -29,7 +29,7 @@ from dataretrieval.configuration import (
 from dataretrieval.credentials import refuse_credential_keywords
 from dataretrieval.exceptions import DataCurrencyWarning
 
-from ._querying import _query_with_retry
+from ._querying import _materialize_query_iterables, _query_with_retry
 from ._wqx import _attach_datetime_columns
 
 __all__ = [
@@ -139,8 +139,7 @@ def get_results(
     countycode : string
         US county FIPS code.
     huc : string or iterable of strings
-        Eight-digit hydrologic unit (HUC). Iterable values are encoded as
-        repeated parameters for WQX3 and semicolon-delimited for legacy WQP.
+        Eight-digit hydrologic unit (HUC).
     bBox : string
         Search bounding box (Example: bBox=-92.8,44.2,-88.9,46.0).
     lat : string
@@ -150,9 +149,7 @@ def get_results(
     within : string
         Radial-search distance in decimal miles.
     pCode : string or iterable of strings
-        Five-digit USGS parameter code. Iterable values are encoded as
-        repeated parameters for WQX3 and semicolon-delimited for legacy WQP.
-        NWIS only.
+        Five-digit USGS parameter code. NWIS only.
     startDateLo : string
         Date of the earliest desired data-collection activity,
         expressed as 'MM-DD-YYYY'.
@@ -161,9 +158,7 @@ def get_results(
         expressed as 'MM-DD-YYYY'.
     characteristicName : string or iterable of strings
         One or more case-sensitive characteristic names
-        (https://www.waterqualitydata.us/public_srsnames/). Iterable values are
-        encoded as repeated parameters for WQX3 and semicolon-delimited for
-        legacy WQP.
+        (https://www.waterqualitydata.us/public_srsnames/).
     mimeType : string
         Output format. Only 'csv' is supported at this time.
 
@@ -749,7 +744,9 @@ def _check_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     ``**queryables`` passthrough: ``api_key=`` is a plausible guess on any
     getter now that ``configure(Configuration(api_key=...))`` is the spelling,
     and this is the adapter with the widest passthrough -- ten getters, whose
-    filter names the portal rather than this package defines.
+    filter names the portal rather than this package defines. The returned
+    payload materializes non-string iterables as lists so one-shot iterators
+    remain reusable by both request serialization and response metadata.
     """
     refuse_credential_keywords(kwargs)
 
@@ -761,7 +758,7 @@ def _check_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     else:
         kwargs["mimeType"] = "csv"
 
-    return kwargs
+    return _materialize_query_iterables(kwargs)
 
 
 def _warn_wqx3_use() -> None:

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -138,8 +138,9 @@ def get_results(
         US state FIPS code (Example: Illinois is "US:17").
     countycode : string
         US county FIPS code.
-    huc : string
-        Eight-digit hydrologic unit (HUC), delimited by semicolons.
+    huc : string or iterable of strings
+        Eight-digit hydrologic unit (HUC). Iterable values are encoded as
+        repeated parameters for WQX3 and semicolon-delimited for legacy WQP.
     bBox : string
         Search bounding box (Example: bBox=-92.8,44.2,-88.9,46.0).
     lat : string
@@ -148,8 +149,9 @@ def get_results(
         Radial-search central longitude in WGS84 decimal degrees.
     within : string
         Radial-search distance in decimal miles.
-    pCode : string
-        Five-digit USGS parameter code, delimited by semicolons.
+    pCode : string or iterable of strings
+        Five-digit USGS parameter code. Iterable values are encoded as
+        repeated parameters for WQX3 and semicolon-delimited for legacy WQP.
         NWIS only.
     startDateLo : string
         Date of the earliest desired data-collection activity,
@@ -157,9 +159,11 @@ def get_results(
     startDateHi : string
         Date of the last desired data-collection activity,
         expressed as 'MM-DD-YYYY'.
-    characteristicName : string
-        One or more case-sensitive characteristic names, separated by
-        semicolons (https://www.waterqualitydata.us/public_srsnames/).
+    characteristicName : string or iterable of strings
+        One or more case-sensitive characteristic names
+        (https://www.waterqualitydata.us/public_srsnames/). Iterable values are
+        encoded as repeated parameters for WQX3 and semicolon-delimited for
+        legacy WQP.
     mimeType : string
         Output format. Only 'csv' is supported at this time.
 
@@ -215,8 +219,9 @@ def get_results(
     if legacy is not True and profile is None:
         kwargs["dataProfile"] = "fullPhysChem"
 
+    delimiter = ";" if legacy else None
     response = _query_with_retry(
-        url, kwargs, delimiter=";", ssl_check=ssl_check, adapter="wqp"
+        url, kwargs, delimiter=delimiter, ssl_check=ssl_check, adapter="wqp"
     )
 
     df = _read_wqp_csv(response.text)
@@ -241,13 +246,15 @@ def _what(
     """
     kwargs = _check_kwargs(kwargs)
 
+    use_wqx3 = service in services_wqx3 and not legacy
     if service in services_wqx3:
-        url = wqp_url(service) if legacy else wqx3_url(service)
+        url = wqx3_url(service) if use_wqx3 else wqp_url(service)
     else:
         url = _legacy_only_url(service, legacy=legacy)
 
+    delimiter = None if use_wqx3 else ";"
     response = _query_with_retry(
-        url, payload=kwargs, delimiter=";", ssl_check=ssl_check, adapter="wqp"
+        url, payload=kwargs, delimiter=delimiter, ssl_check=ssl_check, adapter="wqp"
     )
     df = _read_wqp_csv(response.text)
     return df, WQP_Metadata(response, **kwargs)

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -206,10 +206,12 @@ def get_results(
         valid_profiles = result_profiles_legacy
         kind = "legacy"
         url = wqp_url("Result")
+        delimiter = ";"
     else:
         valid_profiles = result_profiles_wqx3
         kind = "WQX3.0"
         url = wqx3_url("Result")
+        delimiter = None
 
     profile = kwargs.get("dataProfile")
     if profile is not None:
@@ -219,7 +221,6 @@ def get_results(
     if legacy is not True and profile is None:
         kwargs["dataProfile"] = "fullPhysChem"
 
-    delimiter = ";" if legacy else None
     response = _query_with_retry(
         url, kwargs, delimiter=delimiter, ssl_check=ssl_check, adapter="wqp"
     )
@@ -246,13 +247,16 @@ def _what(
     """
     kwargs = _check_kwargs(kwargs)
 
-    use_wqx3 = service in services_wqx3 and not legacy
-    if service in services_wqx3:
-        url = wqx3_url(service) if use_wqx3 else wqp_url(service)
-    else:
+    if service not in services_wqx3:
         url = _legacy_only_url(service, legacy=legacy)
+        delimiter = ";"
+    elif legacy:
+        url = wqp_url(service)
+        delimiter = ";"
+    else:
+        url = wqx3_url(service)
+        delimiter = None
 
-    delimiter = None if use_wqx3 else ";"
     response = _query_with_retry(
         url, payload=kwargs, delimiter=delimiter, ssl_check=ssl_check, adapter="wqp"
     )

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -129,13 +129,13 @@ def test_wqx3_get_results_repeats_list_query_parameters(httpx_mock):
     get_results(
         legacy=False,
         characteristicName=["Carbon", "Total carbon"],
-        siteType=["Stream", "River/Stream"],
+        siteType=["Stream", "Well"],
         dataProfile="basicPhysChem",
     )
 
     params = httpx_mock.get_requests()[-1].url.params
     assert params.get_list("characteristicName") == ["Carbon", "Total carbon"]
-    assert params.get_list("siteType") == ["Stream", "River/Stream"]
+    assert params.get_list("siteType") == ["Stream", "Well"]
 
 
 def test_wqx3_what_sites_repeats_list_query_parameters(httpx_mock):
@@ -143,10 +143,10 @@ def test_wqx3_what_sites_repeats_list_query_parameters(httpx_mock):
     with open("tests/data/wqp_sites.txt") as text:
         httpx_mock.add_response(method="GET", text=text.read())
 
-    what_sites(legacy=False, siteType=["Stream", "River/Stream"])
+    what_sites(legacy=False, siteType=["Stream", "Well"])
 
     params = httpx_mock.get_requests()[-1].url.params
-    assert params.get_list("siteType") == ["Stream", "River/Stream"]
+    assert params.get_list("siteType") == ["Stream", "Well"]
 
 
 @pytest.mark.parametrize(

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -121,6 +121,34 @@ def test_get_results_WQX3(httpx_mock):
     assert df["Activity_StartDateTime"].notna().all()
 
 
+def test_wqx3_get_results_repeats_list_query_parameters(httpx_mock):
+    """WQX3 array filters use repeated keys rather than semicolons."""
+    with open("tests/data/wqp3_results.txt") as text:
+        httpx_mock.add_response(method="GET", text=text.read())
+
+    get_results(
+        legacy=False,
+        characteristicName=["Carbon", "Total carbon"],
+        siteType=["Stream", "River/Stream"],
+        dataProfile="basicPhysChem",
+    )
+
+    params = httpx_mock.get_requests()[-1].url.params
+    assert params.get_list("characteristicName") == ["Carbon", "Total carbon"]
+    assert params.get_list("siteType") == ["Stream", "River/Stream"]
+
+
+def test_wqx3_what_sites_repeats_list_query_parameters(httpx_mock):
+    """The WQX3 serializer also applies to metadata search endpoints."""
+    with open("tests/data/wqp_sites.txt") as text:
+        httpx_mock.add_response(method="GET", text=text.read())
+
+    what_sites(legacy=False, siteType=["Stream", "River/Stream"])
+
+    params = httpx_mock.get_requests()[-1].url.params
+    assert params.get_list("siteType") == ["Stream", "River/Stream"]
+
+
 @pytest.mark.parametrize(
     ("builder", "service", "expected", "warning"),
     [

--- a/tests/wqp_test.py
+++ b/tests/wqp_test.py
@@ -138,6 +138,52 @@ def test_wqx3_get_results_repeats_list_query_parameters(httpx_mock):
     assert params.get_list("siteType") == ["Stream", "Well"]
 
 
+@pytest.mark.parametrize(
+    "values_factory",
+    [
+        pytest.param(lambda: ("Carbon", "Total carbon"), id="tuple"),
+        pytest.param(
+            lambda: (value for value in ("Carbon", "Total carbon")), id="generator"
+        ),
+        pytest.param(
+            lambda: DataFrame({"value": ["Carbon", "Total carbon"]})["value"],
+            id="series",
+        ),
+    ],
+)
+def test_wqx3_get_results_repeats_iterable_query_parameters(httpx_mock, values_factory):
+    """WQX3 materializes non-list iterables before httpx serialization."""
+    with open("tests/data/wqp3_results.txt") as text:
+        httpx_mock.add_response(method="GET", text=text.read())
+
+    _df, md = get_results(
+        legacy=False,
+        characteristicName=values_factory(),
+        dataProfile="basicPhysChem",
+    )
+
+    params = httpx_mock.get_requests()[-1].url.params
+    assert params.get_list("characteristicName") == ["Carbon", "Total carbon"]
+    assert params.get_list("dataProfile") == ["basicPhysChem"]
+    assert list(md._parameters["characteristicName"]) == ["Carbon", "Total carbon"]
+
+
+def test_legacy_get_results_preserves_generator_values_in_metadata(httpx_mock):
+    """Legacy serialization must not leave an exhausted metadata iterator."""
+    with open("tests/data/wqp_results.txt") as text:
+        httpx_mock.add_response(method="GET", text=text.read())
+
+    _df, md = get_results(
+        legacy=True,
+        pCode=(value for value in ("00010", "00300")),
+        dataProfile="narrowResult",
+    )
+
+    params = httpx_mock.get_requests()[-1].url.params
+    assert params.get_list("pCode") == ["00010;00300"]
+    assert md._parameters["pCode"] == ["00010", "00300"]
+
+
 def test_wqx3_what_sites_repeats_list_query_parameters(httpx_mock):
     """The WQX3 serializer also applies to metadata search endpoints."""
     with open("tests/data/wqp_sites.txt") as text:


### PR DESCRIPTION
## Summary
- preserve iterable WQX3 query values so httpx encodes them as repeated keys
- retain semicolon-delimited serialization for legacy WQP endpoints
- document and test array parameters for WQX3 result and station searches

## Validation
- `pytest -q tests/wqp_test.py` (34 passed)
- `coverage run -m pytest tests/ && coverage report -m` (997 passed, 12 deselected; 98% coverage)
- `ruff check .`
- `ruff format --check .`
- `mypy`
- `xenon --max-absolute C --max-modules B --max-average A dataretrieval`
- `complexipy dataretrieval`
- `lint-imports`

Fixes #389