### PR TITLE
docs: use the glossary's terms for collections and locations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,7 +123,10 @@ service differs.
 `service=` (`'dv'`, `'peaks'`); WQP names its collections as profiles
 (`Result`, `Station`, `Activity`). Those parameters are frozen public surface
 and keep their spelling. Prose says *collection*, including prose about the
-adapters that spell it otherwise.
+adapters that spell it otherwise — with one exception: deprecated NWIS keeps
+`service` in its docstrings as well as its parameters. Describing a parameter
+in a term its own module never uses helps nobody, and a module being retired is
+not where new vocabulary should land.
 
 **Collection family** — A group of collections sharing a shape and therefore a
 getter signature. Their getters deliberately resemble one another; the

--- a/dataretrieval/ogc/planning.py
+++ b/dataretrieval/ogc/planning.py
@@ -202,8 +202,9 @@ class _Axis:
         The args-dict key this axis substitutes back into when a
         chunk is rendered.
     atoms : tuple of str
-        The smallest indivisible units along this axis (one site, one
-        OR-clause, …). A "chunk" is a contiguous slice of ``atoms``.
+        The smallest indivisible units along this axis (one monitoring
+        location, one OR-clause, …). A "chunk" is a contiguous slice of
+        ``atoms``.
     joiner : str
         Separator placed between atoms when they are joined back into
         URL text — ``","`` for list axes, ``" OR "`` for the filter

--- a/dataretrieval/waterdata/measurements.py
+++ b/dataretrieval/waterdata/measurements.py
@@ -252,10 +252,11 @@ def get_peaks(
 ) -> tuple[pd.DataFrame, BaseMetadata]:
     """Get the annual peak streamflow / stage record for a monitoring location.
 
-    Peaks are the largest values observed at a site each water year and are
-    the standard input to flood-frequency analysis (e.g. log-Pearson Type III
-    fits). The endpoint returns one row per (monitoring location, parameter,
-    water year), with the peak ``value`` and the ``time`` it occurred.
+    Peaks are the largest values observed at a monitoring location each water
+    year and are the standard input to flood-frequency analysis (e.g.
+    log-Pearson Type III fits). The endpoint returns one row per (monitoring
+    location, parameter, water year), with the peak ``value`` and the ``time``
+    it occurred.
 
     The collection covers both stage (parameter ``"00065"``, ``ft``) and
     discharge (parameter ``"00060"``, ``ft^3/s``); a typical streamgage has a
@@ -338,7 +339,7 @@ def get_peaks(
     --------
     .. code::
 
-        >>> # Full annual peak record at one site (both stage and discharge)
+        >>> # Full annual peak record at one location (stage and discharge)
         >>> df, md = dataretrieval.waterdata.get_peaks(
         ...     monitoring_location_id="USGS-02238500"
         ... )

--- a/dataretrieval/waterdata/metadata.py
+++ b/dataretrieval/waterdata/metadata.py
@@ -828,7 +828,7 @@ site_type_code : string or iterable of strings, optional
         ... )
 
         >>> # Two-step "what's available?" → "fetch it" workflow:
-        >>> # 1. inventory the sites in two HUCs
+        >>> # 1. inventory the monitoring locations in two HUCs
         >>> hucs, _ = dataretrieval.waterdata.get_combined_metadata(
         ...     hydrologic_unit_code=["11010008", "11010009"],
         ...     site_type="Stream",

--- a/dataretrieval/waterdata/ratings.py
+++ b/dataretrieval/waterdata/ratings.py
@@ -135,9 +135,9 @@ def get_ratings(
         One feature of the batch failed *deterministically* -- a stale
         catalog entry (404 on its data asset), a feature with no data asset,
         a malformed RDB file. That feature is skipped and its id is absent
-        from the returned dict; the rest of the batch is unaffected. A site
-        with no published rating never warns -- it matches no feature in the
-        search, so there is nothing to skip. See
+        from the returned dict; the rest of the batch is unaffected. A
+        monitoring location with no published rating never warns -- it
+        matches no feature in the search, so there is nothing to skip. See
         :class:`~dataretrieval.exceptions.SkippedItemWarning` for the policy
         (transients never skip) and the ``filterwarnings`` recipe that makes
         a skip fatal.

--- a/dataretrieval/waterdata/samples.py
+++ b/dataretrieval/waterdata/samples.py
@@ -382,8 +382,8 @@ def get_samples_summary(
     row per (characteristic group, characteristic, user-supplied characteristic)
     combination with result and activity counts and the first / most recent
     activity dates — useful for taking inventory of what discrete-sample data
-    exists at a site before pulling the underlying observations with
-    :func:`get_samples`.
+    exists at a monitoring location before pulling the underlying observations
+    with :func:`get_samples`.
 
     The summary service is single-site only: it accepts exactly one monitoring
     location per request.

--- a/dataretrieval/waterdata/time_series.py
+++ b/dataretrieval/waterdata/time_series.py
@@ -233,11 +233,12 @@ def get_daily(
         ...     last_modified="P7D",
         ... )
 
-        >>> # Chain queries: pull all stream sites in a state, then their
-        >>> # daily discharge for the last week. The site list can be hundreds
-        >>> # of values long — the request is transparently chunked across
-        >>> # multiple chunks so the URL stays under the server's byte
-        >>> # limit. Combined output looks like a single query.
+        >>> # Chain queries: pull all stream monitoring locations in a
+        >>> # state, then their daily discharge for the last week. The
+        >>> # location list can be hundreds of values long — the request
+        >>> # is transparently chunked across multiple chunks so the URL
+        >>> # stays under the server's byte limit. Combined output looks
+        >>> # like a single query.
         >>> sites_df, _ = dataretrieval.waterdata.get_monitoring_locations(
         ...     state="Ohio",
         ...     site_type="Stream",

--- a/dataretrieval/wqp.py
+++ b/dataretrieval/wqp.py
@@ -4,7 +4,7 @@ See https://waterqualitydata.us/webservices_documentation for the API reference.
 
 .. todo::
 
-    - implement other services like Organization, Activity, etc.
+    - implement other collections like Organization, Activity, etc.
 
 """
 
@@ -155,14 +155,14 @@ def _query_wqp(
     legacy: bool,
     **kwargs: Any,
 ) -> tuple[DataFrame, WQP_Metadata]:
-    """Run one WQP getter query against the selected service.
+    """Run one WQP getter query against the selected collection.
 
-    Services with a WQX3.0 equivalent (those in :data:`services_wqx3`) use
-    :func:`wqx3_url` when ``legacy=False`` and :func:`wqp_url` otherwise.
-    Legacy-only services route through :func:`_legacy_only_url`, which warns
-    and falls back to the legacy profile. ``dataProfile`` is validated against
-    :data:`_PROFILE_RULES`, and the CSV response is parsed via
-    :func:`_read_wqp_csv`.
+    Collections with a WQX3.0 equivalent (those in :data:`services_wqx3`,
+    which keeps its legacy name) use :func:`wqx3_url` when ``legacy=False``
+    and :func:`wqp_url` otherwise. Legacy-only collections route through
+    :func:`_legacy_only_url`, which warns and falls back to the legacy
+    profile. ``dataProfile`` is validated against :data:`_PROFILE_RULES`, and
+    the CSV response is parsed via :func:`_read_wqp_csv`.
     """
     kwargs = _check_kwargs(kwargs)
     kwargs = _resolve_profile(service, legacy, kwargs)
@@ -184,7 +184,7 @@ def _query_wqp(
     )
     df = _read_wqp_csv(response.text)
     # Only get_results documents the appended DateTime columns and the
-    # activity-start sort, so the other services keep their parsed shape.
+    # activity-start sort, so the other collections keep their parsed shape.
     if service == "Result":
         df = _attach_datetime_columns(df)
     return df, WQP_Metadata(response, **kwargs)


### PR DESCRIPTION
## Why

A glossary pass over the package, scoped to the modules that are **not**
deprecated. Prose says *collection* where it meant one of a service's named
sets of records, and *monitoring location* where it meant a place measurements
are recorded.

Parameters are untouched throughout. `site_type=`, `site_type_code=` and the
`sites_df` example variable are the services' own vocabulary and stay as they
are — that is the anti-corruption boundary working, not drift.

## What changed

- `waterdata/` — `measurements`, `metadata`, `ratings`, `samples`,
  `time_series`: docstring prose and example comments.
- `ogc/planning.py` — shared OGC machinery serves both Water Data and NGWMN, so
  nothing in it is about one service's spelling.
- `wqp.py` — `_query_wqp`'s docstring and the module `todo`. WQP's profiles
  (`Result`, `Station`, `Activity`) are collections; the reference to
  `services_wqx3` now notes that the name itself is legacy.
- `CONTEXT.md` — one *Known legacy names* bullet, below.

## Legacy NWIS is deliberately excluded

`service=` on the NWIS getters does name a collection. It is also frozen public
surface on a module being retired, so the parameter keeps its name **and its
docstrings keep the same word** — describing a parameter in a term the module
itself never uses helps nobody, and the module is not where new vocabulary
should be landing. The `CONTEXT.md` bullet records that scope.

`NEWS.md` is left alone for the same reason. The two entries this originally
touched are both about deprecated NWIS, and shipped release notes are a
historical record rather than prose to bring into line.

## Prose only

No executable code changed, verified by comparing the AST of every touched
module against `upstream/main` with docstrings stripped:

```
7 .py files changed; executable code differs in: NONE
```

1139 tests pass, `ruff format --check` clean.

## Deferred, with a home

- **`wqp.services_wqx3` / `wqp.services_legacy`** hold collection names and are
  public. Tracked in #406 §3 — it needs an ADR 0012 deprecation cycle, not a
  prose PR.
- **The `censored` → *partly dated* wording** in `nwis.py`, its tests, and the
  08/27 NEWS entry. A genuine terminology problem (in water data a *censored*
  value is one outside a detection limit — a meaning this package ships in
  `wqp.what_detection_limits`), but it is confined to deprecated NWIS and its
  release notes, so it is out of scope here. Worth its own small PR if wanted.
- **The pandas `UserWarning`** raised in the first draft of this PR is fixed in
  #403.

## Relationship to the other open PRs

Based directly on `main`. Touches no file #396 or #400 touches except
`CONTEXT.md`.

**#405 overlaps here.** It restructures *Known legacy names* and, under ADR
0013, moves domain terms at an adapter's surface out of that section and into
the term's own entry — where NWIS's `service=` is already named. Whichever
merges second should fold this bullet into the **Collection** entry rather than
keep both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAEQqs7XzQHGQQi2KakuXD
