### PR TITLE
chore: catch doubled words in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,15 +20,6 @@ repos:
       - id: check-yaml
       - id: debug-statements
 
-  # A doubled word is almost always a slip, and mechanical renames are how they
-  # get in: a regex that rewrites one word of a phrase can leave its neighbour
-  # standing, so "a source label" ends up naming the same noun twice. Nothing
-  # else here reads prose, and AST-level checks strip docstrings before
-  # comparing, which is exactly where such a slip hides.
-  #
-  # Line-scoped on purpose. Matching across a newline as well finds nothing new
-  # in practice and reports a heading followed by its own first word, or
-  # ``return df`` above ``df``: 19 such reports against 0 real ones.
   - repo: local
     hooks:
       - id: doubled-word

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,24 @@ repos:
       - id: check-yaml
       - id: debug-statements
 
+  # A doubled word is almost always a slip, and mechanical renames are how they
+  # get in: a regex that rewrites one word of a phrase can leave its neighbour
+  # standing, so "a source label" ends up naming the same noun twice. Nothing
+  # else here reads prose, and AST-level checks strip docstrings before
+  # comparing, which is exactly where such a slip hides.
+  #
+  # Line-scoped on purpose. Matching across a newline as well finds nothing new
+  # in practice and reports a heading followed by its own first word, or
+  # ``return df`` above ``df``: 19 such reports against 0 real ones.
+  - repo: local
+    hooks:
+      - id: doubled-word
+        name: doubled word
+        language: pygrep
+        entry: \b([A-Za-z]+)[ \t]+\1\b
+        types: [text]
+        exclude: ^tests/data/
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:

--- a/demos/hydroshare/USGS_WaterData_Samples_Examples.ipynb
+++ b/demos/hydroshare/USGS_WaterData_Samples_Examples.ipynb
@@ -100,7 +100,7 @@
     "        A user supplied characteristic name describing one or more results.\n",
     "        Use `get_codes(code_service=\"observedproperty\")` for all possible inputs.\n",
     "* **boundingBox**: list of four floats, optional\n",
-    "        Filters on the the associated monitoring location's point location\n",
+    "        Filters on the associated monitoring location's point location\n",
     "        by checking if it is located within the specified geographic area. \n",
     "        The logic is inclusive, i.e. it will include locations that overlap\n",
     "        with the edge of the bounding box. Values are separated by commas,\n",

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1025,9 +1025,9 @@ def test_broken_config_does_not_break_unrelated_services(config_file):
 def test_default_config_path_follows_a_changed_home(tmp_path, monkeypatch):
     """The default path derives from the home variable, so the memo watches it.
 
-    Which variable that is is platform-specific: ``ntpath.expanduser`` reads
-    ``USERPROFILE`` and ignores ``HOME``, so setting ``HOME`` on Windows moves
-    nothing and this asserted against the runner's real home directory.
+    Which variable that is depends on the platform: ``ntpath.expanduser``
+    reads ``USERPROFILE`` and ignores ``HOME``, so setting ``HOME`` on Windows
+    moves nothing and this asserted against the runner's real home directory.
     """
     home_var = "USERPROFILE" if os.name == "nt" else "HOME"
     monkeypatch.delenv(configuration.CONFIG_PATH_ENV, raising=False)


### PR DESCRIPTION
## Why

A mechanical rename on another branch this week left **`"a label label"`** in a
docstring — `\bsource\b` matched inside the phrase *"a source label"* and
rewrote only the first word.

Everything green-lit it. Tests passed, `mypy --strict` passed, ruff passed, and
an AST comparison proving the change was behaviour-neutral passed — **because
that check strips docstrings before comparing**. It is silent by construction
about exactly the text a rename most easily breaks. Only reading the diff by eye
found it.

A doubled word is the mechanical signature of that mistake, and it costs
nothing to check.

## Measured before adding

A gate that mostly cries wolf is worse than none, so:

| | result |
|---|---|
| tracked text files scanned | 168 |
| false positives | **0** |
| real defects found on first run | **1** |

Restricting the word to `[A-Za-z]+` is what buys the zero. `\w+` also matches
RDB column types such as `10n 10n` in the fixture captures.

## What its first run found

A typo in a **user-facing demo notebook**, shipped and read past:

> "Filters on ~~the the~~ associated monitoring location's point location"

The only other hit was a genuinely clumsy test docstring — *"Which variable that
is is platform-specific"* — which is correct English but poor prose. Reworded
rather than excluded, so the hook needs **no exclusion list** beyond
`tests/data/`, which the existing prose hooks already skip because it holds
byte-exact API captures.

## Line-scoped on purpose

`--multiline` was tried and rejected. It catches a doubled word split across a
wrapped line, but this repo's prose and code produce that shape legitimately all
the time — a Markdown heading followed by its own first word, `return df` above
`df`, `import sys` above `sys`:

```
prose (.md/.rst):  4 cross-line reports, 0 real
code  (.py):      15 cross-line reports, 0 real
```

19 reports, none of them defects. Line-scoped catches the shape a mechanical
rename actually produces, which is the one that got past every other gate.

## It can fail

A gate never seen to fail is not evidence of anything. Seeding a doubled word
makes it exit 1 and name the location:

```
doubled word.............................................................Failed
- hook id: doubled-word
- exit code: 1
dataretrieval/nwis.py:1267:# seeded the the slip
```

The hook was run against that seed before being kept.

## Scope

`.pre-commit-config.yaml`, one notebook typo, one reworded docstring.
Independent of #400, #402 and #403. 1139 tests pass; every hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAEQqs7XzQHGQQi2KakuXD
