### PR TITLE
docs: fix noun-stack over 3 modifiers in metadata docstring

### DIFF
--- a/dataretrieval/waterdata/metadata.py
+++ b/dataretrieval/waterdata/metadata.py
@@ -215,7 +215,7 @@ def get_monitoring_locations(
     construction_date : string or iterable of strings, optional
         Date the well was completed.
     aquifer_code : string or iterable of strings, optional
-        Local aquifers in the USGS water resources data base are identified by a
+        Local aquifers in the USGS database of water resources are identified by a
         geohydrologic unit code (a three-digit number related to the age of the
         formation, followed by a 4 or 5 character abbreviation for the geologic
         unit or aquifer name). Additional information is available


### PR DESCRIPTION
## Summary
Repo-wide review for noun stacks deeper than 3 modifiers before a head noun (per the style rule: cap at three modifiers, convert the rest to a prepositional phrase).

Scanned prose across `README.md`, `AGENTS.md`, `CONTEXT.md`, `CONTRIBUTING.md`, `NEWS.md`, `docs/source/**`, and every docstring/comment in `dataretrieval/`. The corpus is deliberately edited prose (per the domain-modeling/writing-for-agents conventions already in place) and almost entirely clean. Found one genuine violation:

- `dataretrieval/waterdata/metadata.py` (`get_monitoring_locations` docstring, `aquifer_code` parameter): **"the USGS water resources data base"** — four modifiers (`USGS`, `water`, `resources`, `data`) stacked before the head noun `base`. Rewritten as **"the USGS database of water resources"**, converting one modifier into a prepositional phrase. Also fixes the stray "data base" → "database" spelling inconsistency with the rest of the codebase.

## Not changed (reviewed and kept as-is)
- **"the new Water Data STAC catalog"** (`NEWS.md`) and its recurrences in `dataretrieval/waterdata/ratings.py`, `dataretrieval/rdb.py`, and demos: technically 4 modifiers before "catalog," but `Water Data` is a frozen core-term/service name (`CONTEXT.md`) and `STAC` is a fixed external standard's acronym — this is one consistently-used compound proper noun, not an arbitrary stack, and it appears identically across multiple files. Rewriting it in one spot would create inconsistency without a clear readability gain.
- The equivalent phrasing in `R/dataRetrieval/man/*.Rd` and `R/dataRetrieval/vignettes/*.Rmd` is out of scope — `AGENTS.md` explicitly marks `R/` as untracked local scratch, not part of this repo.

## Testing
- `ruff format --check` / `ruff check` pass on the changed file.
- Pre-commit hooks (ruff, mypy, xenon, complexipy, import-linter) all passed on the commit.
- Docstring-only change; no behavior, no tests needed.
